### PR TITLE
Disable tab key capturing inside the proxy table. Fixes (nekoray#1301)

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -196,6 +196,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         group->Save();
     });
     ui->proxyListTable->verticalHeader()->setDefaultSectionSize(24);
+    ui->proxyListTable->setTabKeyNavigation(false);
 
     // search box
     ui->search->setVisible(false);


### PR DESCRIPTION
This PR aims to fix the issue with QT table component that captures the Tab key and prevents the user from escaping and getting out of it. After applying this patch, the user can still navigate the table using arrow keys instead of Tab.

This should fix the issue [#1301](https://github.com/MatsuriDayo/nekoray/issues/1301) reported on the main nekoray repo.