### PR TITLE
refactor: improve speedtest

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -3,6 +3,5 @@
 *.json
 *.exe
 *.dat
-/cmd/nekoray_core/nekoray_core
 /cmd/nekobox_core/nekobox_core
 *.db


### PR DESCRIPTION
* Clearly error return
* Use arguments instead of function closures
* Use upstream context