### PR TITLE
fix: correct Tun Stack settings to match actual behavior

### DIFF
--- a/db/ConfigBuilder.cpp
+++ b/db/ConfigBuilder.cpp
@@ -486,7 +486,7 @@ namespace NekoGui {
             inboundObj["auto_route"] = true;
             inboundObj["endpoint_independent_nat"] = true;
             inboundObj["mtu"] = dataStore->vpn_mtu;
-            inboundObj["stack"] = Preset::SingBox::VpnImplementation.value(dataStore->vpn_implementation);
+            inboundObj["stack"] = dataStore->vpn_implementation;
             inboundObj["strict_route"] = dataStore->vpn_strict_route;
             inboundObj["gso"] = dataStore->enable_gso;
             inboundObj["auto_redirect"] = dataStore->auto_redirect;

--- a/fmt/Preset.hpp
+++ b/fmt/Preset.hpp
@@ -2,7 +2,7 @@
 
 namespace Preset {
     namespace SingBox {
-        inline QStringList VpnImplementation = {"gvisor", "system", "mixed"};
+        inline QStringList VpnImplementation = {"mixed", "system", "gvisor"};
         inline QStringList DomainStrategy = {"", "ipv4_only", "ipv6_only", "prefer_ipv4", "prefer_ipv6"};
         inline QStringList UtlsFingerPrint = {"", "chrome", "firefox", "edge", "safari", "360", "qq", "ios", "android", "random", "randomized", "chrome_psk", "chrome_psk_shuffle", "chrome_padding_psk_shuffle", "chrome_pq", "chrome_pq_psk"};
         inline QStringList ShadowsocksMethods = {"2022-blake3-aes-128-gcm", "2022-blake3-aes-256-gcm", "2022-blake3-chacha20-poly1305", "none", "aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "rc4-md5", "chacha20-ietf", "xchacha20"};

--- a/main/NekoGui.cpp
+++ b/main/NekoGui.cpp
@@ -271,7 +271,7 @@ namespace NekoGui {
         _add(new configItem("active_routing", &active_routing, itemType::string));
         _add(new configItem("mw_size", &mw_size, itemType::string));
         _add(new configItem("disable_traffic_stats", &disable_traffic_stats, itemType::boolean));
-        _add(new configItem("vpn_impl", &vpn_implementation, itemType::integer));
+        _add(new configItem("vpn_impl", &vpn_implementation, itemType::string));
         _add(new configItem("vpn_mtu", &vpn_mtu, itemType::integer));
         _add(new configItem("vpn_ipv6", &vpn_ipv6, itemType::boolean));
         _add(new configItem("vpn_strict_route", &vpn_strict_route, itemType::boolean));

--- a/main/NekoGui_DataStore.hpp
+++ b/main/NekoGui_DataStore.hpp
@@ -123,7 +123,7 @@ namespace NekoGui {
         bool fake_dns = false;
         bool enable_gso = false;
         bool auto_redirect = false;
-        int vpn_implementation = 0;
+        QString vpn_implementation;
         int vpn_mtu = 9000;
         bool vpn_ipv6 = false;
         bool vpn_strict_route = false;

--- a/ui/dialog_vpn_settings.cpp
+++ b/ui/dialog_vpn_settings.cpp
@@ -1,6 +1,7 @@
 #include "dialog_vpn_settings.h"
 #include "ui_dialog_vpn_settings.h"
 
+#include "fmt/Preset.hpp"
 #include "main/GuiUtils.hpp"
 #include "main/NekoGui.hpp"
 #include "ui/mainwindow_interface.h"
@@ -11,7 +12,8 @@ DialogVPNSettings::DialogVPNSettings(QWidget *parent) : QDialog(parent), ui(new 
     ui->setupUi(this);
     ADD_ASTERISK(this);
 
-    ui->vpn_implementation->setCurrentIndex(NekoGui::dataStore->vpn_implementation);
+    ui->vpn_implementation->addItems(Preset::SingBox::VpnImplementation);
+    ui->vpn_implementation->setCurrentText(NekoGui::dataStore->vpn_implementation);
     ui->vpn_mtu->setCurrentText(Int2String(NekoGui::dataStore->vpn_mtu));
     ui->vpn_ipv6->setChecked(NekoGui::dataStore->vpn_ipv6);
     ui->gso_enable->setChecked(NekoGui::dataStore->enable_gso);
@@ -32,7 +34,7 @@ void DialogVPNSettings::accept() {
     //
     auto mtu = ui->vpn_mtu->currentText().toInt();
     if (mtu > 10000 || mtu < 1000) mtu = 9000;
-    NekoGui::dataStore->vpn_implementation = ui->vpn_implementation->currentIndex();
+    NekoGui::dataStore->vpn_implementation = ui->vpn_implementation->currentText();
     NekoGui::dataStore->vpn_mtu = mtu;
     NekoGui::dataStore->vpn_ipv6 = ui->vpn_ipv6->isChecked();
     NekoGui::dataStore->vpn_strict_route = ui->strict_route->isChecked();

--- a/ui/dialog_vpn_settings.ui
+++ b/ui/dialog_vpn_settings.ui
@@ -38,21 +38,9 @@
       </item>
       <item>
        <widget class="QComboBox" name="vpn_implementation">
-        <item>
-         <property name="text">
-          <string notr="true">Mixed</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">gVisor</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string notr="true">System</string>
-         </property>
-        </item>
+        <property name="editable">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
The settings for the Tun Stack in the UI are currently inconsistent with the actual behavior. 
Mixed >> gvisor
gVisor >> system
System >> mixed

This PR corrects these settings to ensure alignment with the actual implementation.