### PR TITLE
Replace networksetup with an absolute path

### DIFF
--- a/core/cmd/nekobox_core/internal/sys/set_dns_darwin.go
+++ b/core/cmd/nekobox_core/internal/sys/set_dns_darwin.go
@@ -15,7 +15,7 @@ func SetSystemDNS(addr string, interfaceMonitor tun.DefaultInterfaceMonitor) err
 		return err
 	}
 
-	err = shell.Exec("networksetup", "-setdnsservers", interfaceDisplayName, addr).Attach().Run()
+	err = shell.Exec("/usr/sbin/networksetup", "-setdnsservers", interfaceDisplayName, addr).Attach().Run()
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,7 @@ func SetSystemDNS(addr string, interfaceMonitor tun.DefaultInterfaceMonitor) err
 }
 
 func getInterfaceDisplayName(name string) (string, error) {
-	content, err := shell.Exec("networksetup", "-listallhardwareports").ReadOutput()
+	content, err := shell.Exec("/usr/sbin/networksetup", "-listallhardwareports").ReadOutput()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Because isolation causes $PATH to be empty at runtime, using an absolute path fixes error that `execute (networksetup) networksetup - listallhardwareports: exec: “networksetup”. executable file not found in $PATH ` #246