### PR TITLE
fix: check the existence of geo-assets in specific paths

### DIFF
--- a/include/global/NekoGui.hpp
+++ b/include/global/NekoGui.hpp
@@ -8,13 +8,13 @@
 // Switch core support
 
 namespace NekoGui {
-    QString FindCoreAsset(const QString &name);
-
     QString FindNekoBoxCoreRealPath();
 
     bool IsAdmin(bool forceRenew=false);
 
     QString GetBasePath();
+
+    QString GetCoreAssetDir(const QString &name);
 
     bool NeedGeoAssets();
 } // namespace NekoGui

--- a/src/global/NekoGui.cpp
+++ b/src/global/NekoGui.cpp
@@ -354,24 +354,6 @@ namespace NekoGui {
 
     // System Utils
 
-    QString FindCoreAsset(const QString &name) {
-        QStringList search{QApplication::applicationDirPath()};
-        search << "/usr/share/sing-geoip";
-        search << "/usr/share/sing-geosite";
-        search << "/usr/share/v2ray";
-        search << "/usr/share/sing-box";
-        search << "/usr/local/share/v2ray";
-        search << "/opt/v2ray";
-        for (const auto &dir: search) {
-            if (dir.isEmpty()) continue;
-            QFileInfo asset(dir + "/" + name);
-            if (asset.exists()) {
-                return asset.absoluteFilePath();
-            }
-        }
-        return {};
-    }
-
     QString FindNekoBoxCoreRealPath() {
         auto fn = QApplication::applicationDirPath() + "/nekobox_core";
         auto fi = QFileInfo(fn);
@@ -404,10 +386,27 @@ namespace NekoGui {
         return qApp->applicationDirPath();
     }
 
+    QString GetCoreAssetDir(const QString &name) {
+        QStringList search = {
+            QApplication::applicationDirPath(),
+            QStringLiteral("/usr/share/sing-geoip"),
+            QStringLiteral("/usr/share/sing-geosite"),
+            QStringLiteral("/usr/share/sing-box"),
+        };
+
+        for (const auto &dir: search) {
+            if (dir.isEmpty())
+                continue;
+
+            QFileInfo asset(QStringLiteral("%1/%2").arg(dir, name));
+            if (asset.exists())
+                return dir;
+        }
+
+        return QString();
+    }
+
     bool NeedGeoAssets(){
-        auto path = GetBasePath();
-        auto geoIP = QFile(path + "/geoip.db");
-        auto geoSite = QFile(path + "/geosite.db");
-        return !geoIP.exists() || !geoSite.exists();
+        return GetCoreAssetDir("geoip.db").isEmpty() || GetCoreAssetDir("geosite.db").isEmpty();
     }
 } // namespace NekoGui

--- a/src/ui/setting/RouteItem.cpp
+++ b/src/ui/setting/RouteItem.cpp
@@ -65,8 +65,14 @@ RouteItem::RouteItem(QWidget *parent, const std::shared_ptr<NekoGui::RoutingChai
 
     // setup rule set helper
     bool ok; // for now we discard this
-    auto geoIpList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::ip, NekoGui::GetBasePath());
-    auto geoSiteList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::site, NekoGui::GetBasePath());
+    auto geoIpList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::ip, [] {
+        QString geoIpDir = NekoGui::GetCoreAssetDir("geoip.db");
+        return geoIpDir.isEmpty() ? NekoGui::GetBasePath() : geoIpDir;
+    }());
+    auto geoSiteList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::site, [] {
+        QString geoSiteDir = NekoGui::GetCoreAssetDir("geosite.db");
+        return geoSiteDir.isEmpty() ? NekoGui::GetBasePath() : geoSiteDir;
+    }());
     geo_items << geoIpList << geoSiteList;
     rule_set_editor = new AutoCompleteTextEdit("", geo_items, this);
     ui->rule_attr_data->layout()->addWidget(rule_set_editor);

--- a/src/ui/setting/dialog_manage_routes.cpp
+++ b/src/ui/setting/dialog_manage_routes.cpp
@@ -141,8 +141,14 @@ DialogManageRoutes::DialogManageRoutes(QWidget *parent) : QDialog(parent), ui(ne
     });
 
     bool ok;
-    auto geoIpList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::ip, NekoGui::GetBasePath());
-    auto geoSiteList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::site, NekoGui::GetBasePath());
+    auto geoIpList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::ip, [] {
+        QString geoIpDir = NekoGui::GetCoreAssetDir("geoip.db");
+        return geoIpDir.isEmpty() ? NekoGui::GetBasePath() : geoIpDir;
+    }());
+    auto geoSiteList = NekoGui_rpc::defaultClient->GetGeoList(&ok, NekoGui_rpc::GeoRuleSetType::site, [] {
+        QString geoSiteDir = NekoGui::GetCoreAssetDir("geosite.db");
+        return geoSiteDir.isEmpty() ? NekoGui::GetBasePath() : geoSiteDir;
+    }());
     QStringList ruleItems = {"domain:", "suffix:", "regex:"};
     for (const auto& geoIP : geoIpList) {
         ruleItems.append("ruleset:"+geoIP);


### PR DESCRIPTION
The existence of `geoip.db` and `geosite.db` should be checked by calling `FindCoreAsset()`.