### PR TITLE
Improve VC check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
 #ifdef Q_OS_WIN
     if (!checkVCRedist())
     {
-        QMessageBox::critical(nullptr, "Cannot run Nekoray", "You need to install VC 2022 Redistributable, Download it from: https://aka.ms/vs/17/release/vc_redist.x64.exe");
+        QMessageBox::critical(nullptr, "Cannot run Nekoray", "You need to install VC 2022 Redistributable.<br>Download it from <a href='https://aka.ms/vs/17/release/vc_redist.x64.exe'>here</a>".);
         return 1;
     }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
 #ifdef Q_OS_WIN
     if (!checkVCRedist())
     {
-        QMessageBox::critical(nullptr, "Cannot run Nekoray", "You need to install VC 2022 Redistributable.<br>Download it from <a href='https://aka.ms/vs/17/release/vc_redist.x64.exe'>here</a>".);
+        QMessageBox::critical(nullptr, "Cannot run Nekoray", "You need to install VC 2022 Redistributable.<br>Download it from <a href='https://aka.ms/vs/17/release/vc_redist.x64.exe'>here</a>.");
         return 1;
     }
 #endif

--- a/src/sys/windows/vcCheck.cpp
+++ b/src/sys/windows/vcCheck.cpp
@@ -6,5 +6,5 @@ bool checkVCRedist()
 {
     QSettings settings("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\x64", QSettings::NativeFormat);
 
-    return (settings.value("Installed").toInt() == 1);
+    return (settings.value("Installed").toInt() == 1 ? settings.value("Bld").toInt() >= 32919 : false);
 }


### PR DESCRIPTION
The minimum vcredist version supported by QT 6.8 is 14.38.32919.0. So we also need to check the vc Build(Bld) number in registry and make sure it >= 32919.
Display the download hyperlink in QMessageBox.
![msg](https://github.com/user-attachments/assets/7fc016b5-e37d-400d-84e1-fd62e617ccd7)
