### PR TITLE
Add with_grpc to build tags.  Support gRPC transport in V2Ray protocols

### DIFF
--- a/script/build_go.sh
+++ b/script/build_go.sh
@@ -26,5 +26,5 @@ popd
 #### Go: core ####
 pushd core/server
 VERSION_SINGBOX=$(go list -m -f '{{.Version}}' github.com/sagernet/sing-box)
-go build -v -o $DEST -trimpath -ldflags "-w -s -X 'github.com/sagernet/sing-box/constant.Version=${VERSION_SINGBOX}'" -tags "with_clash_api,with_gvisor,with_quic,with_wireguard,with_utls,with_ech,with_dhcp"
+go build -v -o $DEST -trimpath -ldflags "-w -s -X 'github.com/sagernet/sing-box/constant.Version=${VERSION_SINGBOX}'" -tags "with_clash_api,with_gvisor,with_quic,with_wireguard,with_utls,with_ech,with_dhcp,with_grpc"
 popd


### PR DESCRIPTION
GUI can create vmess-grpc, vless-grpc or trojan-grpc profile. But core built without gRPC transport support.
![](https://github.com/user-attachments/assets/45a0f853-9e92-41d6-8383-5ffabe5f5cd0)