### PR TITLE
Migrate to QtNetwork for HTTP(s) requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ list(APPEND CMAKE_PREFIX_PATH ${NKR_LIBS})
 if(WIN32)
     list(APPEND CMAKE_PREFIX_PATH "libs/deps/built/x64-windows-static")
 endif ()
-add_definitions(-DCURL_STATICLIB)
 
 message("[CMAKE_PREFIX_PATH] ${CMAKE_PREFIX_PATH}")
 
@@ -65,9 +64,6 @@ list(APPEND NKR_EXTERNAL_TARGETS yaml-cpp)
 
 find_package(ZXing CONFIG REQUIRED)
 list(APPEND NKR_EXTERNAL_TARGETS ZXing::ZXing)
-
-find_package(cpr REQUIRED)
-list(APPEND NKR_EXTERNAL_TARGETS cpr::cpr)
 
 set(BUILD_SHARED_LIBS OFF)
 list(APPEND NKR_EXTERNAL_TARGETS qhotkey)

--- a/include/api/gRPC.h
+++ b/include/api/gRPC.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifndef NKR_NO_GRPC
-
 #include "core/server/gen/libcore.pb.h"
 #include <QString>
 
@@ -54,4 +52,3 @@ namespace NekoGui_rpc {
 
     inline Client *defaultClient;
 } // namespace NekoGui_rpc
-#endif

--- a/include/global/HTTPRequestHelper.hpp
+++ b/include/global/HTTPRequestHelper.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QNetworkRequest>
 #include <QObject>
 #include <functional>
 
@@ -26,7 +23,7 @@ namespace NekoGui_network {
 
         static QString GetHeader(const QList<QPair<QByteArray, QByteArray>> &header, const QString &name);
 
-        static QString DownloadAsset(const QString &url, const QString &fileName, bool isTemp);
+        static QString DownloadAsset(const QString &url, const QString &fileName);
     };
 } // namespace NekoGui_network
 

--- a/script/build_deps_all.sh
+++ b/script/build_deps_all.sh
@@ -19,7 +19,7 @@ mkdir -p $INSTALL_PREFIX
 
 #### clean ####
 clean() {
-  rm -rf dl.zip yaml-* zxing-* protobuf curl cpr libpsl* zlib vcpkg
+  rm -rf dl.zip yaml-* zxing-* protobuf
 }
 
 #### ZXing v2.3.0 ####
@@ -68,47 +68,6 @@ $cmake .. -GNinja \
 ninja && ninja install
 
 cd ../..
-
-if [[ "$(uname -s)" == *"NT"* ]]; then
-  git clone https://github.com/Microsoft/vcpkg.git
-  cd vcpkg
-  export VCPKG_BUILD_TYPE="release"
-  export VCPKG_LIBRARY_LINKAGE="static"
-  ./bootstrap-vcpkg.sh
-  ./vcpkg integrate install
-  ./vcpkg install curl:x64-windows-static --x-install-root=$INSTALL_PREFIX
-
-  cd ..
-
-  git clone https://github.com/libcpr/cpr.git
-  cd cpr
-  git checkout bb01c8db702fb41e5497aee9c0559ddf4bf13749
-  sed -i 's/find_package(CURL COMPONENTS HTTP HTTPS)/find_package(CURL REQUIRED)/g' CMakeLists.txt
-  mkdir build && cd build
-  cmake -GNinja .. -DCMAKE_BUILD_TYPE=Release -DCPR_USE_SYSTEM_CURL=ON -DBUILD_SHARED_LIBS=OFF -DCURL_STATICLIB=ON -DCMAKE_OSX_ARCHITECTURES=$1 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCURL_LIBRARY=../../built/x64-windows-static/lib -DCURL_INCLUDE_DIR=../../built/x64-windows-static/include -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX
-  ninja && ninja install
-
-  cd ../..
-
-  else
-    git clone https://github.com/curl/curl.git
-    cd curl
-    git checkout 7eb8c048470ed2cc14dca75be9c1cdae7ac8498b
-    mkdir build && cd build
-    cmake -GNinja .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES=$1 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCURL_STATICLIB=ON -DUSE_LIBIDN2=OFF
-    ninja && ninja install
-
-    cd ../..
-
-    git clone https://github.com/libcpr/cpr.git
-    cd cpr
-    git checkout bb01c8db702fb41e5497aee9c0559ddf4bf13749
-    mkdir build && cd build
-    cmake -GNinja .. -DCMAKE_BUILD_TYPE=Release -DCPR_USE_SYSTEM_CURL=ON -DBUILD_SHARED_LIBS=OFF -DCURL_STATICLIB=ON -DCMAKE_OSX_ARCHITECTURES=$1 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX
-    ninja && ninja install
-
-    cd ../..
-fi
 
 ####
 clean

--- a/script/deploy_linux64.sh
+++ b/script/deploy_linux64.sh
@@ -53,7 +53,7 @@ patchelf --set-rpath '$ORIGIN/../../lib' ./usr/plugins/platformthemes/libqxdgdes
 # fix extra libs...
 mkdir ./usr/lib2
 ls ./usr/lib/
-cp ./usr/lib/libQt* ./usr/lib/libxcb-util* ./usr/lib/libicuuc* ./usr/lib/libicui18n* ./usr/lib/libicudata* ./usr/lib/libssl* ./usr/lib/libcrypto* ./usr/lib2
+cp ./usr/lib/libQt* ./usr/lib/libxcb-util* ./usr/lib/libicuuc* ./usr/lib/libicui18n* ./usr/lib/libicudata* ./usr/lib2
 rm -r ./usr/lib
 mv ./usr/lib2 ./usr/lib
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,11 +19,6 @@
 #include "include/sys/windows/MiniDump.h"
 #include "include/sys/windows/vcCheck.h"
 #include "include/sys/windows/eventHandler.h"
-#pragma comment (lib, "cpr.lib")
-#pragma comment (lib, "libcurl.lib")
-#pragma comment (lib, "Ws2_32.lib")
-#pragma comment (lib, "Wldap32.lib")
-#pragma comment (lib, "Crypt32.lib")
 #endif
 
 void signal_handler(int signum) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2094,14 +2094,14 @@ void MainWindow::DownloadAssets(const QString &geoipUrl, const QString &geositeU
     MW_show_log("Start downloading...");
     QString errors;
     if (!geoipUrl.isEmpty()) {
-        auto resp = NetworkRequestHelper::DownloadAsset(geoipUrl, "geoip.db", true);
+        auto resp = NetworkRequestHelper::DownloadAsset(geoipUrl, "geoip.db");
         if (!resp.isEmpty()) {
             MW_show_log(QString(tr("Failed to download geoip: %1")).arg(resp));
             errors += "geoip: " + resp;
         }
     }
     if (!geositeUrl.isEmpty()) {
-        auto resp = NetworkRequestHelper::DownloadAsset(geositeUrl, "geosite.db", true);
+        auto resp = NetworkRequestHelper::DownloadAsset(geositeUrl, "geosite.db");
         if (!resp.isEmpty()) {
             MW_show_log(QString(tr("Failed to download geosite: %1")).arg(resp));
             errors += "\ngeosite: " + resp;
@@ -2193,7 +2193,7 @@ void MainWindow::CheckUpdate() {
         });
         return;
     }
-    
+
     auto resp = NetworkRequestHelper::HttpGet("https://api.github.com/repos/Mahdi-zarei/nekoray/releases");
     if (!resp.error.isEmpty()) {
         runOnUiThread([=] {
@@ -2201,7 +2201,7 @@ void MainWindow::CheckUpdate() {
         });
         return;
     }
-    
+
     QString assets_name, release_download_url, release_url, release_note, note_pre_release;
     bool exitFlag = false;
     QJsonArray array = QString2QJsonArray(resp.data);
@@ -2252,7 +2252,7 @@ void MainWindow::CheckUpdate() {
                 }
                 QString errors;
                 if (!release_download_url.isEmpty()) {
-                    auto res = NetworkRequestHelper::DownloadAsset(release_download_url, "nekoray.zip", false);
+                    auto res = NetworkRequestHelper::DownloadAsset(release_download_url, "nekoray.zip");
                     if (!res.isEmpty()) {
                         errors += res;
                     }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2177,7 +2177,7 @@ void MainWindow::CheckUpdate() {
 	search = "windows32";
 #  endif
 #endif
-#if defined(Q_OS_LINUX) && defined(Q_PROCESSOR_X86_64)
+#ifdef Q_OS_LINUX && Q_PROCESSOR_X86_64
 	search = "linux64";
 #endif
 #ifdef Q_OS_MACOS


### PR DESCRIPTION
Advantage:
* The nekogui is using QtNetwork as gRPC client. Migrating to QtNetwork for HTTP requests shouldn't add a new dependency.
* Remove cpr and curl dependencies.