### PR TITLE
style(ui): align bottom labels horizontally centered in mainwindow

### DIFF
--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -451,7 +451,7 @@
               <attribute name="title">
                <string>Traffic Graph</string>
               </attribute>
-              <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="">
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
                <property name="spacing">
                 <number>0</number>
                </property>
@@ -488,6 +488,9 @@
         <property name="text">
          <string/>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item>
@@ -511,12 +514,18 @@
         <property name="text">
          <string/>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="label_speed">
         <property name="text">
          <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/004414fe-d5f0-414e-b113-c40c9605e8fc)
I think centering the bottom label texts looks more aesthetically pleasing.