### PR TITLE
Hide dock icon

### DIFF
--- a/res/MacOSXBundleInfo.plist
+++ b/res/MacOSXBundleInfo.plist
@@ -32,5 +32,7 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
I would like to suggest hiding the Dock icon for MacOS version, as in my opinion it's unnecessary and takes up space, especially since the app is already accessible from the menu bar.