### PR TITLE
Add "Minimize to tray" checkbox

### DIFF
--- a/include/global/NekoGui_DataStore.hpp
+++ b/include/global/NekoGui_DataStore.hpp
@@ -64,6 +64,7 @@ namespace NekoGui {
         // Misc
         QString log_level = "info";
         QString test_latency_url = "http://cp.cloudflare.com/";
+        bool minimize_to_tray = true; // move app to tray instead of closing it
         int test_concurrent = 10;
         bool disable_traffic_stats = false;
         int current_group = 0; // group id

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -180,6 +180,28 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="horizontalGroupBox_1_5">
+         <layout class="QHBoxLayout" name="horizontalLayout_1_5">
+          <item>
+           <widget class="QCheckBox" name="minimize_to_tray">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Minimize to tray</string>
+            </property>
+            <property name="toolTip">
+             <string>Clicking the 'X' will move the application to the system tray instead of closing it</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QFrame" name="frame">
          <property name="frameShape">
           <enum>QFrame::Shape::StyledPanel</enum>

--- a/res/translations/fa_IR.ts
+++ b/res/translations/fa_IR.ts
@@ -142,6 +142,14 @@ For nekobox_core, this rewrites the underlying(localhost) DNS in Tun Mode, norma
         <translation type="unfinished">آدرس تست تاخیر</translation>
     </message>
     <message>
+        <source>Minimize to tray</source>
+        <translation>به سینی کوچک کنید</translation>
+    </message>
+    <message>
+        <source>Clicking the 'X' will move the application to the system tray instead of closing it</source>
+        <translation>با کلیک بر روی «X»، برنامه به جای بسته شدن به سینی سیستم منتقل می‌شود.</translation>
+    </message>
+    <message>
         <source>Automatic update</source>
         <translation type="unfinished">آپدیت اتوماتیک</translation>
     </message>

--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -36,6 +36,14 @@
         <translation>Параллельно</translation>
     </message>
     <message>
+        <source>Minimize to tray</source>
+        <translation>Сворачивать в трей</translation>
+    </message>
+    <message>
+        <source>Clicking the 'X' will move the application to the system tray instead of closing it</source>
+        <translation>Нажатие на 'X' переместит приложение в системный трей вместо его закрытия</translation>
+    </message>
+    <message>
         <source>Style</source>
         <translation>Стиль</translation>
     </message>

--- a/res/translations/zh_CN.ts
+++ b/res/translations/zh_CN.ts
@@ -142,6 +142,14 @@ For nekobox_core, this rewrites the underlying(localhost) DNS in Tun Mode, norma
         <translation>测试延迟 URL</translation>
     </message>
     <message>
+        <source>Minimize to tray</source>
+        <translation>最小化到托盘</translation>
+    </message>
+    <message>
+        <source>Clicking the 'X' will move the application to the system tray instead of closing it</source>
+        <translation>单击“X”将把应用程序移动到系统托盘而不是关闭它</translation>
+    </message>
+    <message>
         <source>Automatic update</source>
         <translation>自动更新</translation>
     </message>

--- a/src/global/NekoGui.cpp
+++ b/src/global/NekoGui.cpp
@@ -241,6 +241,7 @@ namespace NekoGui {
     DataStore::DataStore() : JsonStore() {
         _add(new configItem("user_agent2", &user_agent, itemType::string));
         _add(new configItem("test_url", &test_latency_url, itemType::string));
+        _add(new configItem("minimize_to_tray", &minimize_to_tray, itemType::boolean));
         _add(new configItem("current_group", &current_group, itemType::integer));
         _add(new configItem("inbound_address", &inbound_address, itemType::string));
         _add(new configItem("inbound_socks_port", &inbound_socks_port, itemType::integer));

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -521,6 +521,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
+    if (!NekoGui::dataStore->minimize_to_tray) {
+        on_menu_exit_triggered();
+    }
     if (tray->isVisible()) {
         hide();
         event->ignore();

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -33,6 +33,7 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     D_LOAD_INT(inbound_socks_port)
     D_LOAD_INT(test_concurrent)
     D_LOAD_STRING(test_latency_url)
+    D_LOAD_BOOL(minimize_to_tray)
     ui->speedtest_mode->setCurrentIndex(NekoGui::dataStore->speed_test_mode);
 
     connect(ui->custom_inbound_edit, &QPushButton::clicked, this, [=] {
@@ -167,6 +168,7 @@ void DialogBasicSettings::accept() {
     D_SAVE_INT(inbound_socks_port)
     D_SAVE_INT(test_concurrent)
     D_SAVE_STRING(test_latency_url)
+    D_SAVE_BOOL(minimize_to_tray)
     NekoGui::dataStore->proxy_scheme = ui->proxy_scheme->currentText().toLower();
     NekoGui::dataStore->speed_test_mode = ui->speedtest_mode->currentIndex();
 


### PR DESCRIPTION
It would be cool if you could adjust the behavior of the app when closing. It is not always convenient to minimize the app to the tray. If I am used to closing the app on Alt-F4, I want it to close. The app does not have such a setting, so I did it myself.

- Add a "Minimize to tray" checkbox in the basic settings window
- Implement the logic to handle it
- The state is stored in the config file and retrieved when needed
- Include translations for all supported languages

![image](https://github.com/user-attachments/assets/ba3712aa-163d-44c7-a355-49c6d05a1c30)
