### PR TITLE
Improve start menu shortcut

### DIFF
--- a/script/windows_installer.nsi
+++ b/script/windows_installer.nsi
@@ -42,11 +42,8 @@ Section "Install"
   File /r ".\deployment\windows64\*"
 
   CreateShortcut "$desktop\Throne.lnk" "$instdir\Throne.exe"
-
-  CreateDirectory "$SMPROGRAMS\Throne"
-  CreateShortcut "$SMPROGRAMS\Throne\Throne.lnk" "$INSTDIR\Throne.exe" "" "$INSTDIR\Throne.exe" 0
-  CreateShortcut "$SMPROGRAMS\Throne\Uninstall Throne.lnk" "$INSTDIR\uninstall.exe"
-
+  CreateShortcut "$SMPROGRAMS\Throne.lnk" "$INSTDIR\Throne.exe" "" "$INSTDIR\Throne.exe" 0
+  
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Throne" "DisplayName" "Throne"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Throne" "UninstallString" "$INSTDIR\uninstall.exe"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Throne" "InstallLocation" "$INSTDIR"

--- a/script/windows_installer.nsi
+++ b/script/windows_installer.nsi
@@ -56,8 +56,7 @@ Section "Uninstall"
 
   !insertmacro AbortOnRunningApp "$INSTDIR\Throne.exe"
 
-  Delete "$SMPROGRAMS\Throne\Throne.lnk"
-  Delete "$SMPROGRAMS\Throne\Uninstall Throne.lnk"
+  Delete "$SMPROGRAMS\Throne.lnk"
   Delete "$desktop\Throne.lnk"
   RMDir "$SMPROGRAMS\Throne"
 


### PR DESCRIPTION
سلام، واقعا نیازی نیست برای برنامه‌ای که فقط یه شورت‌کات دارد، یک فولدر ساخته شود.

<img width="1668" height="834" alt="image" src="https://github.com/user-attachments/assets/42d530ac-cee4-44ee-9532-184f1d908fe7" />

با اعمال این تغییر، شورت‌کات برنامه هم میاد کنار شورت‌کات مابقی برنامه‌ها:

`%AppData%\Microsoft\Windows\Start Menu\Programs`