### PR TITLE
Fix: avoid core cannot found rule set when program startup

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -426,7 +426,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         }
     });
 
-	auto srslist = QFile(QApplication::applicationDirPath() + "/srslist");
+	auto srslist = QFile("srslist");
     if (srslist.exists()) {
         if (srslist.open(QIODevice::ReadOnly)) {
             QByteArray byteArray = srslist.readAll();
@@ -435,27 +435,31 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
             srsvec.assign(byteArray.begin(), byteArray.end());
             ruleSetMap = spb::pb::deserialize<libcore::RuleSet>(srsvec).items;
         }
-    } else {
-        auto getRuleSet = [=,this]
-        {
-            QString err;
-            for(int retry = 0; retry < 5; retry++) {
-                auto resp = NetworkRequestHelper::HttpGet(Configs::get_jsdelivr_link("https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/list"));
-                if (resp.error.isEmpty()) {
-                    std::vector<uint8_t> respvec;
-                    respvec.assign(resp.data.begin(), resp.data.end());
-                    auto reply = spb::pb::deserialize<libcore::RuleSet>(respvec);
-                    ruleSetMap = reply.items;
-                    return;
-                }
-                else
-                    err = resp.error;
-                QThread::sleep(30);
+    } 
+    auto getRuleSet = [=,this]
+    {
+        QString err;
+        for(int retry = 0; retry < 5; retry++) {
+            auto resp = NetworkRequestHelper::HttpGet(Configs::get_jsdelivr_link("https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/list"));
+            if (resp.error.isEmpty()) {
+                std::vector<uint8_t> respvec;
+                respvec.assign(resp.data.begin(), resp.data.end());
+                auto reply = spb::pb::deserialize<libcore::RuleSet>(respvec);
+                ruleSetMap = reply.items;
+                QFile file;
+                file.setFileName("srslist");
+                file.open(QIODevice::ReadWrite | QIODevice::Truncate);
+                file.write(resp.data);
+                file.close();
+                return;
             }
-            MW_show_log(QObject::tr("Requesting rule-set list error: %1").arg(err));
-        };
-        runOnNewThread(getRuleSet);
-    }
+            else
+                err = resp.error;
+            QThread::sleep(30);
+        }
+        MW_show_log(QObject::tr("Requesting rule-set list error: %1").arg(err));
+    };
+    runOnNewThread(getRuleSet);
 
     auto getRemoteRouteProfiles = [=,this]
     {


### PR DESCRIPTION
Occurrence load config error when exist rule set  on program startup，because add rule set need ruleSetMap is not empty, but ruleSetMap is empty before request of rule set list return data