### PR TITLE
Multiple UI fixes

### DIFF
--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -2178,7 +2178,7 @@ Release note:
     </message>
     <message>
         <source>Used: %1 Remain: %2 Expire: %3</source>
-        <translation>Использовано: %1, осталось: %2, истекло: %3</translation>
+        <translation>Использовано: %1, осталось: %2, истекает: %3</translation>
     </message>
     <message>
         <source>Default</source>

--- a/src/ui/group/GroupItem.cpp
+++ b/src/ui/group/GroupItem.cpp
@@ -35,7 +35,7 @@ QString ParseSubInfo(const QString &info) {
     }
 
     result = QObject::tr("Used: %1 Remain: %2 Expire: %3")
-                 .arg(ReadableSize(used), ReadableSize(total - used), DisplayTime(expire, QLocale::ShortFormat));
+                         .arg(ReadableSize(used), (total == 0) ? QString::fromUtf8("\u221E") : ReadableSize(total - used), DisplayTime(expire, QLocale::ShortFormat));
 
     return result;
 }

--- a/src/ui/setting/RouteItem.cpp
+++ b/src/ui/setting/RouteItem.cpp
@@ -228,7 +228,9 @@ RouteItem::RouteItem(QWidget *parent, const std::shared_ptr<Configs::RoutingChai
     connect(ui->rule_name, &QLineEdit::textChanged, this, [=,this](const QString& text) {
         if (currentIndex == -1) return;
         chain->Rules[currentIndex]->name = QString(text);
-        updateRouteItemsView();
+        auto ruleNameCursorPosition = ui->rule_name->cursorPosition();
+        updateRouteItemsView(); 
+        ui->rule_name->setCursorPosition(ruleNameCursorPosition);
     });
 
     connect(ui->rule_attr_selector, &QComboBox::currentTextChanged, this, [=,this](const QString& text){


### PR DESCRIPTION
- Fixed display of remaining subscription traffic in the UI (previously, an unlimited subscription displayed a negative number, but now it displays the infinity symbol ∞)
- Russian translation corrected
- Fix cursor position in rule_name field during editing (previously, when editing a rule name, the cursor moved to the end of the line after each character entered)