### PR TITLE
Replace "show window" functionality in tray icon with "toggle window"

### DIFF
--- a/include/global/Utils.hpp
+++ b/include/global/Utils.hpp
@@ -165,6 +165,8 @@ int MessageBoxInfo(const QString &title, const QString &text);
 
 void ActivateWindow(QWidget *w);
 
+void ToggleWindow(QWidget *w);
+
 //
 
 void runOnUiThread(const std::function<void()> &callback);

--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -655,9 +655,9 @@
     <string>Exit</string>
    </property>
   </action>
-  <action name="actionShow_window">
+  <action name="actionToggle_window">
    <property name="text">
-    <string>Show Window</string>
+    <string>Toggle Window</string>
    </property>
   </action>
   <action name="menu_basic_settings">

--- a/src/global/Utils.cpp
+++ b/src/global/Utils.cpp
@@ -249,6 +249,22 @@ void ActivateWindow(QWidget *w) {
     w->activateWindow();
 }
 
+void ToggleWindow(QWidget *w) {
+    if (w->isVisible() && !(w->windowState() & Qt::WindowMinimized)) {
+        // Window is visible → minimize / hide
+        w->hide();
+    } else {
+        // Window is hidden or minimized → show
+        w->setWindowState(w->windowState() & ~Qt::WindowMinimized);
+        w->setVisible(true);
+#ifdef Q_OS_WIN
+        Windows_QWidget_SetForegroundWindow(w);
+#endif
+        w->raise();
+        w->activateWindow();
+    }
+}
+
 void runOnUiThread(const std::function<void()> &callback) {
     // any thread
     auto *timer = new QTimer();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -347,7 +347,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     tray = new QSystemTrayIcon(nullptr);
     tray->setIcon(GetTrayIcon(Icon::NONE));
     auto *trayMenu = new QMenu();
-    trayMenu->addAction(ui->actionShow_window);
+    trayMenu->addAction(ui->actionToggle_window);
     trayMenu->addSeparator();
     trayMenu->addAction(ui->actionStart_with_system);
     trayMenu->addAction(ui->actionRemember_last_proxy);
@@ -362,7 +362,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     tray->setContextMenu(trayMenu);
     connect(tray, &QSystemTrayIcon::activated, qApp, [=, this](QSystemTrayIcon::ActivationReason reason) {
         if (reason == QSystemTrayIcon::Trigger) {
-            ActivateWindow(this);
+            ToggleWindow(this);
         }
     });
 
@@ -375,7 +375,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(ui->menu_add_from_clipboard2, &QAction::triggered, ui->menu_add_from_clipboard, &QAction::trigger);
     connect(ui->actionRestart_Proxy, &QAction::triggered, this, [=,this] { if (Configs::dataStore->started_id>=0) profile_start(Configs::dataStore->started_id); });
     connect(ui->actionRestart_Program, &QAction::triggered, this, [=,this] { MW_dialog_message("", "RestartProgram"); });
-    connect(ui->actionShow_window, &QAction::triggered, this, [=,this] { ActivateWindow(this); });
+    connect(ui->actionToggle_window, &QAction::triggered, this, [=,this] { ToggleWindow(this); });
     connect(ui->actionRemember_last_proxy, &QAction::triggered, this, [=,this](bool checked) {
         Configs::dataStore->remember_enable = checked;
         ui->actionRemember_last_proxy->setChecked(checked);


### PR DESCRIPTION
This PR replaces the existing "Show Window" behavior with a true "Toggle Window" functionality in the system tray icon. On Wayland (**Update: small clarification**[^1]), the standard close-to-tray behavior does not work; some sort of toggle is required to minimize and restore the main window from the tray.

Currently, the only way to minimize the window to tray ~on Wayland~ *in tiling window managers on Wayland*, is to kill the application and start it again (assuming the user has enabled the "start to tray" setting). This is clearly not a good experience...

Changes:

- Added `ToggleWindow(QWidget *w)` in `Utils.cpp`:
  - If the window is visible, hides it (minimize to tray).
  - If the window is hidden or minimized, restores and activates it.
- Updated `mainwindow.cpp`:
  - Tray icon activation and the menu action previously bound to `ActivateWindow()` now call `ToggleWindow()`.
- Updated `mainwindow.ui` to rename the "Show Window" menu item to "Toggle Window".

Behavior:

- Clicking the tray icon or tray icon menu toggles the main window's visibility to/from tray.
- Minimizing to tray works as before; restoring the window behaves consistently across Wayland and X11.
- No additional menu items were added; the existing "Show Window" action was repurposed.

Note: I left the `ActivateWindow(QWidget *w)` function intact, since there may be code paths which explicitly wants to activate the window without risking to minimize it.

Edit: I've tested this on Fedora Linux running Sway window manager.

Edit 2: An alternative solution is to add a new tray menu item called "Minimize to tray" under "Show window", although less elegant in my view. Let me know if this solution is preferred, I'd be happy to amend this PR.

[^1]:
    To clarify, this is not a general Wayland limitation. KDE and GNOME provide a close button that hides the app to tray as expected. The issue arises in tiling WMs like Sway, which lack title bars and close buttons. On X11, tiling WMs such as i3 can send a `WM_DELETE_WINDOW` signal to trigger `closeEvent()`, but Wayland has no equivalent protocol so the application itself must provide a toggle.

    Sorry for not communicating this better from the beginning.
