### PR TITLE
Update to Qt 6.10.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,15 +155,8 @@ jobs:
         with:
           path: qt6/build
           key: QtStaticCache-${{ matrix.platform }}-${{ matrix.target }}-Qt${{ matrix.qt_version }}-${{ hashFiles('script/build_qt_static_windows.bat') }}
-      - name: OpenSSL Cache
-        id: cache-openssl
-        if: matrix.platform == 'windows-latest' && matrix.qt_version != '6.2.12'
-        uses: actions/cache@v4.2.3
-        with:
-          path: ${{ env.VCPKG_ROOT }}/installed/x64-mingw-static
-          key: OpenSSLCache-${{ matrix.platform }}-${{ matrix.target }}
       - name: Install OpenSSL (Windows)
-        if: matrix.platform == 'windows-latest' && steps.cache-openssl.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'
+        if: matrix.platform == 'windows-latest' && steps.cache-static-Qt.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'
         shell: powershell
         run: |
           echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,13 +154,7 @@ jobs:
         uses: actions/cache@v4.2.3
         with:
           path: qt6/build
-          key: QtStaticCache-${{ matrix.platform }}-${{ matrix.target }}-Qt${{ matrix.qt_version }}-${{ hashFiles('script/build_qt_static_windows.bat') }}
-      - name: Install OpenSSL (Windows)
-        if: matrix.platform == 'windows-latest' && steps.cache-static-Qt.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'
-        shell: powershell
-        run: |
-          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-mingw-static
+          key: QtStaticCache-${{ matrix.platform }}-${{ matrix.target }}-Qt${{ matrix.qt_version }}
       - name: Install Qt Windows
         shell: powershell
         if: matrix.platform == 'windows-latest' && steps.cache-static-Qt.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'
@@ -182,7 +176,7 @@ jobs:
           mkdir build
           cd build
           curl -fLso srslist.h "https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/srslist.h"
-          cmake -GNinja -DCMAKE_CXX_FLAGS="-static" -DOPENSSL_ROOT_DIR="$VCPKG_ROOT/installed/x64-mingw-static" -DCMAKE_BUILD_TYPE=Debug ..
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_BUILD_TYPE=Debug ..
           ninja -j2
           cd ..
           ./script/deploy_windows.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
         if: matrix.platform == 'windows-latest' && matrix.qt_version != '6.2.12'
         uses: actions/cache@v4.2.3
         with:
-          path: C:/vcpkg/installed/x64-mingw-static
+          path: ${{ env.VCPKG_INSTALLATION_ROOT }}/installed/x64-mingw-static
           key: OpenSSLCache-${{ matrix.platform }}-${{ matrix.target }}
       - name: Install OpenSSL (Windows)
         if: matrix.platform == 'windows-latest' && steps.cache-openssl.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'
@@ -189,8 +189,8 @@ jobs:
           mkdir build
           cd build
           curl -fLso srslist.h "https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/srslist.h"
-          cmake -GNinja -DCMAKE_CXX_FLAGS="-static" -DOPENSSL_ROOT_DIR="$VCPKG_INSTALLATION_ROOT/installed/x64-mingw-static" -DCMAKE_BUILD_TYPE=Debug ..
-          ninja
+          cmake -GNinja -DCMAKE_CXX_FLAGS="-static" -DOPENSSL_ROOT_DIR="$VCPKG_ROOT/installed/x64-mingw-static" -DCMAKE_BUILD_TYPE=Debug ..
+          ninja -j2
           cd ..
           ./script/deploy_windows.sh
       - name: Legacy Windows - Generate MakeFile and Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
         if: matrix.platform == 'windows-latest' && matrix.qt_version != '6.2.12'
         uses: actions/cache@v4.2.3
         with:
-          path: ${{ env.VCPKG_INSTALLATION_ROOT }}/installed/x64-mingw-static
+          path: ${{ env.VCPKG_ROOT }}/installed/x64-mingw-static
           key: OpenSSLCache-${{ matrix.platform }}-${{ matrix.target }}
       - name: Install OpenSSL (Windows)
         if: matrix.platform == 'windows-latest' && steps.cache-openssl.outputs.cache-hit != 'true' && matrix.qt_version != '6.2.12'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,25 +94,25 @@ jobs:
       matrix:
         include:
           - platform: windows-latest
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: x86_64
           - platform: windows-11-arm
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: arm64
           - platform: ubuntu-22.04
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: amd64
           - platform: ubuntu-22.04
             qt_version: "6.2.0"
             target: amd64
           - platform: ubuntu-24.04-arm
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: arm64
           - platform: macos-latest
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: x86_64
           - platform: macos-latest
-            qt_version: "6.10.0"
+            qt_version: "6.10.1"
             target: arm64
           - platform: macos-latest
             qt_version: "6.4.3"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
           cd build
           curl -fLso srslist.h "https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/srslist.h"
           cmake -GNinja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_BUILD_TYPE=Debug ..
-          ninja -j2
+          ninja
           cd ..
           ./script/deploy_windows.sh
       - name: Legacy Windows - Generate MakeFile and Build

--- a/script/build_qt_static_windows.bat
+++ b/script/build_qt_static_windows.bat
@@ -3,7 +3,7 @@ cd qt6
 
 git switch %1
 mkdir build
-CALL .\configure.bat -openssl-linked -release -static -prefix ./build -static-runtime -submodules qtbase,qtimageformats,qtsvg,qttranslations -skip tests -skip examples -gui -widgets -init-submodules -- -D OPENSSL_ROOT_DIR="%VCPKG_ROOT%/installed/x64-mingw-static"
+CALL .\configure.bat -release -static -prefix ./build -static-runtime -submodules qtbase,qtimageformats,qtsvg,qttranslations -skip tests -skip examples -gui -widgets -init-submodules
 echo on branch %1
 echo config complete, building...
 cmake --build . --parallel


### PR DESCRIPTION
Update to Qt 6.10.1. QTBUG-141061 has been fixed in Qt 6.10.1, revert to using schannel backend for SSL on windows.