### PR TITLE
Add custom system parameters for x-hwid, x-device-os, x-ver-os, x-device-model headers

### DIFF
--- a/include/global/DataStore.hpp
+++ b/include/global/DataStore.hpp
@@ -116,6 +116,7 @@ namespace Configs {
         int sub_auto_update = -30;
         bool sub_clear = false;
         bool sub_send_hwid = false;
+        QString sub_custom_hwid_params = ""; // Custom system parameters: format "hwid=value,os=value,osVersion=value,model=value"
 
         // Security
         bool skip_cert = false;

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -569,6 +569,23 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_custom_hwid_params">
+         <property name="text">
+          <string>Custom System Parameters (optional)</string>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Format: hwid=value,os=value,osVersion=value,model=value&lt;/p&gt;&lt;p&gt;Leave empty to use default values. Only specify the parameters you want to override.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLineEdit" name="sub_custom_hwid_params">
+         <property name="placeholderText">
+          <string>hwid=custom_value,os=custom_os,osVersion=custom_version,model=custom_model</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_20">
          <property name="sizePolicy">

--- a/src/global/Configs.cpp
+++ b/src/global/Configs.cpp
@@ -287,6 +287,7 @@ namespace Configs {
         _add(new configItem("net_insecure", &net_insecure, itemType::boolean));
         _add(new configItem("sub_auto_update", &sub_auto_update, itemType::integer));
         _add(new configItem("sub_send_hwid", &sub_send_hwid, itemType::boolean));
+        _add(new configItem("sub_custom_hwid_params", &sub_custom_hwid_params, itemType::string));
         _add(new configItem("start_minimal", &start_minimal, itemType::boolean));
         _add(new configItem("max_log_line", &max_log_line, itemType::integer));
         _add(new configItem("splitter_state", &splitter_state, itemType::string));

--- a/src/global/HTTPRequestHelper.cpp
+++ b/src/global/HTTPRequestHelper.cpp
@@ -7,6 +7,8 @@
 #include <QTimer>
 #include <QFile>
 #include <QApplication>
+#include <QMap>
+#include <QStringList>
 
 #include "include/global/Configs.hpp"
 #include "include/ui/mainwindow.h"
@@ -40,11 +42,42 @@ namespace Configs_network {
         //Attach HWID and device info headers if enabled in settings
         if (sendHwid) {
             auto details = GetDeviceDetails();
-           
-            if (!details.hwid.isEmpty()) request.setRawHeader("x-hwid", details.hwid.toUtf8());
-            if (!details.os.isEmpty()) request.setRawHeader("x-device-os", details.os.toUtf8());
-            if (!details.osVersion.isEmpty()) request.setRawHeader("x-ver-os", details.osVersion.toUtf8());
-            if (!details.model.isEmpty()) request.setRawHeader("x-device-model", details.model.toUtf8());
+
+            // Parse custom parameters if provided
+            QMap<QString, QString> customParams;
+            if (!Configs::dataStore->sub_custom_hwid_params.isEmpty()) {
+                QStringList pairs = Configs::dataStore->sub_custom_hwid_params.split(',');
+                for (const QString &pair : pairs) {
+                    QString trimmed = pair.trimmed();
+                    int eqPos = trimmed.indexOf('=');
+                    if (eqPos > 0) {
+                        QString key = trimmed.left(eqPos).trimmed();
+                        QString value = trimmed.mid(eqPos + 1).trimmed();
+                        // Validate: key must be one of the allowed parameters, value must not contain newlines
+                        if (!key.isEmpty() && !value.isEmpty() &&
+                            !value.contains('\n') && !value.contains('\r') &&
+                            value.length() < 1000) { // Reasonable length limit
+                            QString lowerKey = key.toLower();
+                            // Only accept known parameter keys
+                            if (lowerKey == "hwid" || lowerKey == "os" ||
+                                lowerKey == "osversion" || lowerKey == "model") {
+                                customParams[lowerKey] = value;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Use custom values if provided, otherwise use default values
+            QString hwid = customParams.contains("hwid") ? customParams["hwid"] : details.hwid;
+            QString os = customParams.contains("os") ? customParams["os"] : details.os;
+            QString osVersion = customParams.contains("osversion") ? customParams["osversion"] : details.osVersion;
+            QString model = customParams.contains("model") ? customParams["model"] : details.model;
+
+            if (!hwid.isEmpty()) request.setRawHeader("x-hwid", hwid.toUtf8());
+            if (!os.isEmpty()) request.setRawHeader("x-device-os", os.toUtf8());
+            if (!osVersion.isEmpty()) request.setRawHeader("x-ver-os", osVersion.toUtf8());
+            if (!model.isEmpty()) request.setRawHeader("x-device-model", model.toUtf8());
         }
         //
         auto _reply = accessManager.get(request);
@@ -59,7 +92,7 @@ namespace Configs_network {
         QEventLoop loop;
         connect(_reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
         loop.exec();
-        
+
         //
         auto result = HTTPResponse{_reply->error() == QNetworkReply::NetworkError::NoError ? "" : _reply->errorString(),
                                        _reply->readAll(), _reply->rawHeaderPairs()};

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -155,6 +155,7 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     D_LOAD_BOOL(sub_clear)
     D_LOAD_BOOL(net_insecure)
     D_LOAD_BOOL(sub_send_hwid)
+    D_LOAD_STRING(sub_custom_hwid_params)
     D_LOAD_INT_ENABLE(sub_auto_update, sub_auto_update_enable)
     auto details = GetDeviceDetails();
 	ui->sub_send_hwid->setToolTip(
@@ -253,6 +254,7 @@ void DialogBasicSettings::accept() {
     D_SAVE_BOOL(sub_clear)
     D_SAVE_BOOL(net_insecure)
     D_SAVE_BOOL(sub_send_hwid)
+    D_SAVE_STRING(sub_custom_hwid_params)
     D_SAVE_INT_ENABLE(sub_auto_update, sub_auto_update_enable)
 
     // Core


### PR DESCRIPTION
Adds ability to customize system parameters (HWID, OS, OS Version, Model) sent in HTTP headers when updating subscriptions.

Changes:
- Added `sub_custom_hwid_params` setting field
- Added UI text field in Basic Settings > Subscription tab
- Implemented parsing logic with validation
- Custom values override defaults when provided
- Empty input falls back to default system parameters
- Users can enter custom parameters in format: `hwid=custom_value,os=custom_os,osVersion=custom_version,model=custom_model`

Notes:
- Comma-separated format (commas in values not supported)
- Case-insensitive parameter keys
- Only accepts known parameters: hwid, os, osversion, model