### PR TITLE
fix: vless xray link parsing

### DIFF
--- a/src/configs/common/utils.cpp
+++ b/src/configs/common/utils.cpp
@@ -52,7 +52,7 @@ namespace Configs
 
         if (query.queryItemValue("type") == "xhttp"
             || query.queryItemValue("security") == "reality"
-            || query.queryItemValue("encryption") != "none"
+            || (query.queryItemValue("encryption") != "none" && query.queryItemValue("encryption") != "")
             || query.queryItemValue("extra") != "") return true;
         return false;
     }

--- a/src/configs/common/xrayStreamSetting.cpp
+++ b/src/configs/common/xrayStreamSetting.cpp
@@ -205,7 +205,7 @@ namespace Configs {
         auto query = QUrlQuery(url.query());
 
         if (query.hasQueryItem("host")) host = query.queryItemValue("host");
-        if (query.hasQueryItem("path")) path = query.queryItemValue("path");
+        if (query.hasQueryItem("path")) path = query.queryItemValue("path", QUrl::FullyDecoded);
         if (query.hasQueryItem("mode")) mode = query.queryItemValue("mode");
         if (query.hasQueryItem("extra")) ParseExtraJson(query.queryItemValue("extra", QUrl::FullyDecoded));
         if (query.hasQueryItem("headers")) headers = query.queryItemValue("headers").split(",");


### PR DESCRIPTION
## Description

- vless-xray: Fix xhttp path containing /
- Fix detection of vless with `encryption` != `""` (3x-ui + WebSocket link in my case)