### PR TITLE
Fix: update check message for the latest version

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2576,7 +2576,7 @@ bool isNewer(QString assetName) {
         }
     } else
     {
-        MW_show_log("Version strings seem to be invalid" + QString(NKR_VERSION) + " and " + version);
+		MW_show_log("There are no updates. You have the latest version - " + QString(NKR_VERSION));
         return false;
     }
     return false;


### PR DESCRIPTION
Previously, when the current version was the latest, the log message incorrectly stated "Version strings seem to be invalid", which could confuse users.

This change updates the message to:

 `"There are no updates. You have the latest version - <current_version>"`

This makes it clear that the software is up-to-date without implying an error.