### PR TITLE
fix: restore default keyboard shortcuts & add new ones

### DIFF
--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -657,6 +657,9 @@
    <property name="text">
     <string>Exit</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+W</string>
+   </property>
   </action>
   <action name="actionShow_window">
    <property name="text">
@@ -667,15 +670,24 @@
    <property name="text">
     <string>Basic Settings</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+,</string>
+   </property>
   </action>
   <action name="menu_add_from_input">
    <property name="text">
     <string>New profile</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+N</string>
+   </property>
   </action>
   <action name="menu_manage_groups">
    <property name="text">
     <string>Groups</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+G</string>
    </property>
   </action>
   <action name="menu_start">
@@ -697,6 +709,9 @@
   <action name="menu_routing_settings">
    <property name="text">
     <string>Routing Settings</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+O</string>
    </property>
   </action>
   <action name="menu_add_from_clipboard">
@@ -781,6 +796,9 @@
   <action name="menu_scan_qr">
    <property name="text">
     <string>Scan QR Code</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+Q</string>
    </property>
   </action>
   <action name="menu_spmode_system_proxy">
@@ -867,6 +885,9 @@
    <property name="text">
     <string>Hotkey Settings</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+K</string>
+   </property>
   </action>
   <action name="menu_select_all">
    <property name="text">
@@ -947,15 +968,24 @@
    <property name="text">
     <string>Tun Settings</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+T</string>
+   </property>
   </action>
   <action name="actionRestart_Program">
    <property name="text">
     <string>Restart Program</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+F5</string>
+   </property>
   </action>
   <action name="menu_open_config_folder">
    <property name="text">
     <string>Open Config Folder</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+E</string>
    </property>
   </action>
   <action name="actionfake_4">
@@ -978,10 +1008,16 @@
    <property name="text">
     <string>Restart Proxy</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">F5</string>
+   </property>
   </action>
   <action name="menu_stop_testing">
    <property name="text">
     <string>Stop Testing</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+.</string>
    </property>
   </action>
   <action name="actionUrl_Test_Selected">
@@ -1037,25 +1073,40 @@
    <property name="text">
     <string>Speedtest Current</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">F6</string>
+   </property>
   </action>
   <action name="actionSpeedtest_Selected">
    <property name="text">
     <string>Speedtest Selected</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+P</string>
    </property>
   </action>
   <action name="actionSpeedtest_Group">
    <property name="text">
     <string>Speedtest Group</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Alt+P</string>
+   </property>
   </action>
   <action name="actionHide_window">
    <property name="text">
     <string>Hide window</string>
    </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+H</string>
+   </property>
   </action>
   <action name="actionAdd_profile_from_File">
    <property name="text">
     <string>Add profile from File</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+O</string>
    </property>
   </action>
  </widget>

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2480,8 +2480,10 @@ void MainWindow::loadShortcuts()
     for (QList<QAction *> actions = findChildren<QAction *>(); QAction *action : actions)
     {
         if (action->data().isNull() || action->data().toString().isEmpty()) continue;
-        if (mp.count(action->data().toString()) == 0) action->setShortcut(QKeySequence());
-        else action->setShortcut(mp[action->data().toString()]);
+        // Only apply saved shortcut if user has defined one; preserve default UI shortcuts otherwise
+        if (mp.count(action->data().toString()) > 0) {
+            action->setShortcut(mp[action->data().toString()]);
+        }
     }
 
     RegisterHiddenMenuShortcuts();


### PR DESCRIPTION
## What does this PR do?
Restores keyboard shortcuts and adds new useful ones.

## Problem
As a daily user of Throne, I noticed the app was missing many useful keyboard shortcuts that existed in earlier versions. After investigating, I also found that [loadShortcuts()](cci:1://file:///home/pinkorca/Projects/02_guys/Throne/include/ui/mainwindow.h:254:4-254:25) was clearing newly added shortcuts from the UI file.

## Changes
- Fix [loadShortcuts()](cci:1://file:///home/pinkorca/Projects/02_guys/Throne/include/ui/mainwindow.h:254:4-254:25) to preserve default shortcuts from UI
- Add 17 new keyboard shortcuts (Ctrl+N, Ctrl+G, F5, Ctrl+,, etc.)

## Testing
- Tested on Artix Linux
- All shortcuts visible in menus
- All shortcuts work as expected