### PR TITLE
Fix: Avoid SEGFAULT caused by invalid profiles

### DIFF
--- a/src/dataStore/Group.cpp
+++ b/src/dataStore/Group.cpp
@@ -28,7 +28,12 @@ namespace Configs
         auto res = QList<std::shared_ptr<ProxyEntity>>{};
         for (auto id : profiles)
         {
-            res.append(profileManager->GetProfile(id));
+            auto ent = profileManager->GetProfile(id);
+            if (ent) {
+                res.append(ent);
+            } else {
+                qDebug() << "Found missing profile ID:" << id;
+            }
         }
         return res;
     }


### PR DESCRIPTION
## Description

This PR addresses a silent **SEGFAULT** occurring in `Throne` when the contents of the groups and profiles directories within the `config` folder become **inconsistent**.

Instead of crashing silently, the program now outputs a warning via `QDebug` when meeting an inconsistency and skip this corrupted profile, which helps the program to at least work as normal.

## The Issue

The crash occurs because the program attempts to access an empty `shared_ptr` without prior validation. When data between groups and profiles doesn't match, the pointer remains null, leading to an immediate crash without any debugging information or error messages.

Inconsistencies in configuration files can arise from several scenarios:

*    Malformed subscription files.

*    Legacy bugs in some previous versions of Throne.

*    Process interruptions or crashes during file I/O.

*    File system errors or unexpected system shutdowns.

*    Manual, improper modification of configuration files by the user.

However, Once these inconsistent files are generated, Throne enters a "**crash loop**", making it impossible to update or detect subscriptions to fix the state.

## Known Limitations & Future Work
I was unable to make the `remove unavailable` logic apply to these corrupted profiles without a significant revision of the core logic. This should be a follow-up task.