### PR TITLE
fix: keep Tab focus navigation in autocomplete editor

### DIFF
--- a/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
+++ b/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
@@ -116,6 +116,11 @@ namespace Qv2ray::ui::widgets {
     }
 
     void AutoCompleteTextEdit::keyPressEvent(QKeyEvent *e) {
+        if (e->key() == Qt::Key_Tab || e->key() == Qt::Key_Backtab) {
+            QPlainTextEdit::keyPressEvent(e);
+            return;
+        }
+
         const bool hasCtrlOrShiftModifier = e->modifiers().testFlag(Qt::ControlModifier) || e->modifiers().testFlag(Qt::ShiftModifier);
         const bool hasOtherModifiers = (e->modifiers() != Qt::NoModifier) && !hasCtrlOrShiftModifier; // has other modifiers
         //

--- a/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
+++ b/3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp
@@ -65,6 +65,7 @@ namespace Qv2ray::ui::widgets {
     AutoCompleteTextEdit::AutoCompleteTextEdit(const QString &prefix, const QStringList &sourceStrings, QWidget *parent) : QPlainTextEdit(parent) {
         this->prefix = prefix;
         this->setLineWrapMode(QPlainTextEdit::NoWrap);
+        this->setTabChangesFocus(true);
         c = new QCompleter(this);
         c->setModel(new QStringListModel(sourceStrings, c));
         c->setWidget(this);


### PR DESCRIPTION
## Summary
- Ensure Tab/Shift+Tab in AutoCompleteTextEdit follows normal focus navigation between controls.
- Keep autocomplete behavior for actual text input keys.

## Problem
In Route-related editors that use AutoCompleteTextEdit, pressing Tab can conflict with editing/autocomplete behavior instead of moving focus as expected. This is especially problematic for keyboard-first and screen-reader users.

## Change
- Set setTabChangesFocus(true) in AutoCompleteTextEdit.
- Route Tab/Backtab through base editor handling so they act as focus navigation keys.

## User impact
- Predictable keyboard navigation in Route editors.
- Better accessibility for NVDA/screen-reader workflows.

## File changed
- 3rdparty/qv2ray/v2/ui/QvAutoCompleteTextEdit.cpp

## Attribution
- This fix was prepared with AI assistance and tested by the author.