### PR TITLE
fix: HTTP proxy link parsing missing credential decode logic

### DIFF
--- a/src/configs/outbounds/http.cpp
+++ b/src/configs/outbounds/http.cpp
@@ -15,6 +15,25 @@ namespace Configs {
         outbound::ParseFromLink(link);
         username = url.userName();
         password = url.password();
+
+        // Handle v2rayN format: credentials are base64-encoded in the username field
+        // e.g. http://base64(token)@server:port
+        // If decoded string has no ':', SubStrBefore/After both return the full string,
+        // so username == password == decoded_token (matches expected behavior).
+        if (password.isEmpty() && !username.isEmpty()) {
+            QString decoded = DecodeB64IfValid(username);
+            if (!decoded.isEmpty()) {
+                username = SubStrBefore(decoded, ":");
+                password = SubStrAfter(decoded, ":");
+            }
+        }
+
+        // Handle single-credential format: http://:token@server:port
+        // Some providers set password only; username should equal password.
+        if (username.isEmpty() && !password.isEmpty()) {
+            username = password;
+        }
+
         if (query.hasQueryItem("path")) path = query.queryItemValue("path");
         if (query.hasQueryItem("headers")) headers = query.queryItemValue("headers").split(",");
         if (url.scheme() == "https" || query.queryItemValue("security") == "tls")


### PR DESCRIPTION
Two bugs in http::ParseFromLink() vs socks::ParseFromLink():

1. Missing v2rayN base64 decode: when format is http://base64(token)@server:port and the decoded string has no ':', both SubStrBefore/After return the full decoded string, resulting in username == password == token. http.cpp lacked this decode step that socks.cpp already had.

2. Missing single-credential fallback: when format is http://:token@server:port (password-only, no username), QUrl returns empty userName(). The password token should be copied to username so both fields are non-empty and equal, matching the expected behavior from the subscription provider.

https://claude.ai/code/session_01CaPVoGt2wPPmgYpggKoyJk