### PR TITLE
feat: Customizable tun addr

### DIFF
--- a/core/server/gen/libcore.proto
+++ b/core/server/gen/libcore.proto
@@ -45,6 +45,7 @@ message LoadConfigReq {
   optional bool extra_no_out = 8 [default = false];
   optional bool need_xray = 9 [default = false];
   optional string xray_config = 10 [default = ""];
+  optional string tun_ipv4_cidr = 11 [default = ""];
 }
 
 message URLTestResp {

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -10,6 +10,7 @@ import (
 	"ThroneCore/internal/xray"
 	"ThroneCore/test_utils"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/google/shlex"
@@ -20,6 +21,7 @@ import (
 	"github.com/sagernet/sing/service"
 	"github.com/xtls/xray-core/core"
 	"log"
+	"net/netip"
 	"os"
 	"runtime"
 	"strings"
@@ -42,6 +44,53 @@ type server struct {
 // To returns a pointer to the given value.
 func To[T any](v T) *T {
 	return &v
+}
+
+func deriveTunDNSFromCoreConfig(coreConfig string) (string, bool) {
+	var config map[string]any
+	if err := json.Unmarshal([]byte(coreConfig), &config); err != nil {
+		return "", false
+	}
+
+	inboundsRaw, ok := config["inbounds"].([]any)
+	if !ok {
+		return "", false
+	}
+
+	for _, inboundRaw := range inboundsRaw {
+		inbound, ok := inboundRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		tag, _ := inbound["tag"].(string)
+		inboundType, _ := inbound["type"].(string)
+		if tag != "tun-in" && inboundType != "tun" {
+			continue
+		}
+
+		addressRaw, ok := inbound["address"].([]any)
+		if !ok {
+			continue
+		}
+		for _, raw := range addressRaw {
+			cidr, ok := raw.(string)
+			if !ok {
+				continue
+			}
+			prefix, err := netip.ParsePrefix(cidr)
+			if err != nil || !prefix.Addr().Is4() {
+				continue
+			}
+			dnsIP := prefix.Addr().Next()
+			if !dnsIP.IsValid() || !dnsIP.Is4() {
+				return "", false
+			}
+			return dnsIP.String(), true
+		}
+	}
+
+	return "", false
 }
 
 func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.ErrorResp, _ error) {
@@ -122,8 +171,12 @@ func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.Err
 		}
 		return
 	}
-	if runtime.GOOS == "darwin" && strings.Contains(*in.CoreConfig, "tun-in") && strings.Contains(*in.CoreConfig, "172.19.0.1/24") {
-		err := sys.SetSystemDNS("172.19.0.2", boxInstance.Network().InterfaceMonitor())
+	if runtime.GOOS == "darwin" {
+		tunDNS, ok := deriveTunDNSFromCoreConfig(*in.CoreConfig)
+		if !ok {
+			return
+		}
+		err := sys.SetSystemDNS(tunDNS, boxInstance.Network().InterfaceMonitor())
 		if err != nil {
 			log.Println("Failed to set system DNS:", err)
 		}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -13,6 +13,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"net/netip"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
 	"github.com/google/shlex"
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/experimental/clashapi"
@@ -20,12 +27,6 @@ import (
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/service"
 	"github.com/xtls/xray-core/core"
-	"log"
-	"net/netip"
-	"os"
-	"runtime"
-	"strings"
-	"time"
 )
 
 var boxInstance *boxbox.Box
@@ -46,15 +47,17 @@ func To[T any](v T) *T {
 	return &v
 }
 
-func deriveTunDNSFromCoreConfig(coreConfig string) (string, bool) {
+var ErrNoInboundsInCoreConfig = errors.New("couldn't find \"inbounds\" in the core configuration")
+
+func deriveTunDNSFromCoreConfig(coreConfig string) (string, error) {
 	var config map[string]any
 	if err := json.Unmarshal([]byte(coreConfig), &config); err != nil {
-		return "", false
+		return "", err
 	}
 
 	inboundsRaw, ok := config["inbounds"].([]any)
 	if !ok {
-		return "", false
+		return "", ErrNoInboundsInCoreConfig
 	}
 
 	for _, inboundRaw := range inboundsRaw {
@@ -84,13 +87,13 @@ func deriveTunDNSFromCoreConfig(coreConfig string) (string, bool) {
 			}
 			dnsIP := prefix.Addr().Next()
 			if !dnsIP.IsValid() || !dnsIP.Is4() {
-				return "", false
+				return "", fmt.Errorf("got invalid DNS IP derived from inbound address: %s", dnsIP)
 			}
-			return dnsIP.String(), true
+			return dnsIP.String(), nil
 		}
 	}
 
-	return "", false
+	return "", ErrNoInboundsInCoreConfig
 }
 
 func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.ErrorResp, _ error) {
@@ -172,11 +175,11 @@ func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.Err
 		return
 	}
 	if runtime.GOOS == "darwin" {
-		tunDNS, ok := deriveTunDNSFromCoreConfig(*in.CoreConfig)
-		if !ok {
-			return
+		tunDNS, err := deriveTunDNSFromCoreConfig(*in.CoreConfig)
+		if err != nil {
+			log.Println("Failed to extract IP for system DNS:", err)
 		}
-		err := sys.SetSystemDNS(tunDNS, boxInstance.Network().InterfaceMonitor())
+		err = sys.SetSystemDNS(tunDNS, boxInstance.Network().InterfaceMonitor())
 		if err != nil {
 			log.Println("Failed to set system DNS:", err)
 		}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -10,7 +10,6 @@ import (
 	"ThroneCore/internal/xray"
 	"ThroneCore/test_utils"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -45,55 +44,6 @@ type server struct {
 // To returns a pointer to the given value.
 func To[T any](v T) *T {
 	return &v
-}
-
-var ErrNoInboundsInCoreConfig = errors.New("couldn't find \"inbounds\" in the core configuration")
-
-func deriveTunDNSFromCoreConfig(coreConfig string) (string, error) {
-	var config map[string]any
-	if err := json.Unmarshal([]byte(coreConfig), &config); err != nil {
-		return "", err
-	}
-
-	inboundsRaw, ok := config["inbounds"].([]any)
-	if !ok {
-		return "", ErrNoInboundsInCoreConfig
-	}
-
-	for _, inboundRaw := range inboundsRaw {
-		inbound, ok := inboundRaw.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		tag, _ := inbound["tag"].(string)
-		inboundType, _ := inbound["type"].(string)
-		if tag != "tun-in" && inboundType != "tun" {
-			continue
-		}
-
-		addressRaw, ok := inbound["address"].([]any)
-		if !ok {
-			continue
-		}
-		for _, raw := range addressRaw {
-			cidr, ok := raw.(string)
-			if !ok {
-				continue
-			}
-			prefix, err := netip.ParsePrefix(cidr)
-			if err != nil || !prefix.Addr().Is4() {
-				continue
-			}
-			dnsIP := prefix.Addr().Next()
-			if !dnsIP.IsValid() || !dnsIP.Is4() {
-				return "", fmt.Errorf("got invalid DNS IP derived from inbound address: %s", dnsIP)
-			}
-			return dnsIP.String(), nil
-		}
-	}
-
-	return "", ErrNoInboundsInCoreConfig
 }
 
 func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.ErrorResp, _ error) {
@@ -174,15 +124,46 @@ func (s *server) Start(ctx context.Context, in *gen.LoadConfigReq) (out *gen.Err
 		}
 		return
 	}
-	if runtime.GOOS == "darwin" {
-		tunDNS, err := deriveTunDNSFromCoreConfig(*in.CoreConfig)
-		if err != nil {
-			log.Println("Failed to extract IP for system DNS:", err)
+
+	if runtime.GOOS == "darwin" && strings.Contains(*in.CoreConfig, "tun-in") {
+		stopAllCores := func() {
+			boxInstance.CloseWithTimeout(instanceCancel, time.Second*2, log.Println, true)
+			boxInstance = nil
+			if extraProcess != nil {
+				extraProcess.Stop()
+				extraProcess = nil
+			}
+			if xrayInstance != nil {
+				xrayInstance.Close()
+				xrayInstance = nil
+			}
 		}
-		err = sys.SetSystemDNS(tunDNS, boxInstance.Network().InterfaceMonitor())
-		if err != nil {
+
+		tunCIDR := in.GetTunIpv4Cidr()
+		if tunCIDR == "" {
+			err = errors.New("tun_ipv4_cidr is required for tun-in on macOS")
+			stopAllCores()
+			return
+		}
+
+		tunPrefix, parseErr := netip.ParsePrefix(tunCIDR)
+		if parseErr != nil || !tunPrefix.Addr().Is4() {
+			err = fmt.Errorf("invalid tun_ipv4_cidr %q", tunCIDR)
+			stopAllCores()
+			return
+		}
+
+		tunDNS := tunPrefix.Addr().Next()
+		if !tunDNS.IsValid() || !tunDNS.Is4() {
+			err = fmt.Errorf("got invalid DNS IP from tun_ipv4_cidr: %s", tunDNS)
+			stopAllCores()
+			return
+		}
+
+		if err := sys.SetSystemDNS(tunDNS.String(), boxInstance.Network().InterfaceMonitor()); err != nil {
 			log.Println("Failed to set system DNS:", err)
 		}
+
 		needUnsetDNS = true
 	}
 

--- a/include/configs/generate.h
+++ b/include/configs/generate.h
@@ -66,6 +66,7 @@ namespace Configs
         QString error;
         bool isChained = false;
         QJsonObject coreConfig;
+        QString tunIPv4CIDR;
         bool isXrayNeeded = false;
         QJsonObject xrayConfig;
         std::shared_ptr<ExtraCoreData> extraCoreData = std::make_shared<ExtraCoreData>();

--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -162,7 +162,6 @@ namespace Configs {
 #endif
         int vpn_mtu = 1500;
         bool vpn_ipv6 = false;
-        bool vpn_use_custom_interface_addresses = false;
         QString vpn_tun_ipv4_cidr = "172.19.0.1/24";
         QString vpn_tun_ipv6_cidr = "fdfe:dcba:9876::1/96";
         bool disable_privilege_req = false;

--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -162,6 +162,9 @@ namespace Configs {
 #endif
         int vpn_mtu = 1500;
         bool vpn_ipv6 = false;
+        bool vpn_use_custom_interface_addresses = false;
+        QString vpn_tun_ipv4_cidr = "172.19.0.1/24";
+        QString vpn_tun_ipv6_cidr = "fdfe:dcba:9876::1/96";
         bool disable_privilege_req = false;
 
         // NTP

--- a/include/ui/setting/dialog_vpn_settings.h
+++ b/include/ui/setting/dialog_vpn_settings.h
@@ -25,6 +25,8 @@ public slots:
 
     void accept() override;
 
+    void on_restore_default_addresses_clicked();
+
     void on_troubleshooting_clicked();
 };
 

--- a/include/ui/setting/dialog_vpn_settings.ui
+++ b/include/ui/setting/dialog_vpn_settings.ui
@@ -107,6 +107,50 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="tunAddressGroupBox">
+     <property name="title">
+      <string>Tun Address</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="use_custom_interface_addresses">
+        <property name="text">
+         <string>Use different interface addresses</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_tun_ipv4">
+        <property name="text">
+         <string>IPv4 CIDR</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="tun_ipv4_cidr">
+        <property name="placeholderText">
+         <string notr="true">172.19.0.1/24</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_tun_ipv6">
+        <property name="text">
+         <string>IPv6 CIDR</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="tun_ipv6_cidr">
+        <property name="placeholderText">
+         <string notr="true">fdfe:dcba:9876::1/96</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="troubleshooting">
@@ -130,6 +174,8 @@
   <tabstop>vpn_implementation</tabstop>
   <tabstop>vpn_mtu</tabstop>
   <tabstop>vpn_ipv6</tabstop>
+  <tabstop>tun_ipv4_cidr</tabstop>
+  <tabstop>tun_ipv6_cidr</tabstop>
   <tabstop>strict_route</tabstop>
   <tabstop>troubleshooting</tabstop>
  </tabstops>

--- a/include/ui/setting/dialog_vpn_settings.ui
+++ b/include/ui/setting/dialog_vpn_settings.ui
@@ -112,38 +112,38 @@
       <string>Tun Address</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="use_custom_interface_addresses">
-        <property name="text">
-         <string>Use different interface addresses</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
+      <item row="0" column="0">
        <widget class="QLabel" name="label_tun_ipv4">
         <property name="text">
          <string>IPv4 CIDR</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="QLineEdit" name="tun_ipv4_cidr">
         <property name="placeholderText">
          <string notr="true">172.19.0.1/24</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_tun_ipv6">
         <property name="text">
          <string>IPv6 CIDR</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="tun_ipv6_cidr">
         <property name="placeholderText">
          <string notr="true">fdfe:dcba:9876::1/96</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="restore_default_addresses">
+        <property name="text">
+         <string>Restore default addresses</string>
         </property>
        </widget>
       </item>
@@ -176,6 +176,7 @@
   <tabstop>vpn_ipv6</tabstop>
   <tabstop>tun_ipv4_cidr</tabstop>
   <tabstop>tun_ipv6_cidr</tabstop>
+  <tabstop>restore_default_addresses</tabstop>
   <tabstop>strict_route</tabstop>
   <tabstop>troubleshooting</tabstop>
  </tabstops>

--- a/res/translations/fa_IR.ts
+++ b/res/translations/fa_IR.ts
@@ -1201,8 +1201,8 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <translation>آدرس Tun</translation>
     </message>
     <message>
-        <source>Use different interface addresses</source>
-        <translation>استفاده از آدرس‌های متفاوت برای رابط‌ها</translation>
+        <source>Restore default addresses</source>
+        <translation>بازگردانی آدرس‌های پیش‌فرض</translation>
     </message>
     <message>
         <source>IPv4 CIDR</source>

--- a/res/translations/fa_IR.ts
+++ b/res/translations/fa_IR.ts
@@ -1196,6 +1196,34 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <source>Enable Tun Routing</source>
         <translation>فعال کردن مسیریابی Tun</translation>
     </message>
+    <message>
+        <source>Tun Address</source>
+        <translation>آدرس Tun</translation>
+    </message>
+    <message>
+        <source>Use different interface addresses</source>
+        <translation>استفاده از آدرس‌های متفاوت برای رابط‌ها</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR</source>
+        <translation>CIDR IPv4</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR</source>
+        <translation>CIDR IPv6</translation>
+    </message>
+    <message>
+        <source>Invalid Tun Address</source>
+        <translation>آدرس Tun نامعتبر است</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR is invalid.</source>
+        <translation>CIDR IPv4 نامعتبر است.</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR is invalid.</source>
+        <translation>CIDR IPv6 نامعتبر است.</translation>
+    </message>
 </context>
 <context>
     <name>EditAdvanced</name>

--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -1201,8 +1201,8 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <translation>Адрес TUN</translation>
     </message>
     <message>
-        <source>Use different interface addresses</source>
-        <translation>Использовать другие адреса интерфейса</translation>
+        <source>Restore default addresses</source>
+        <translation>Восстановить адреса по умолчанию</translation>
     </message>
     <message>
         <source>IPv4 CIDR</source>

--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -1196,6 +1196,34 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <source>Enable Tun Routing</source>
         <translation>Вкл. TUN-маршрутизацию</translation>
     </message>
+    <message>
+        <source>Tun Address</source>
+        <translation>Адрес TUN</translation>
+    </message>
+    <message>
+        <source>Use different interface addresses</source>
+        <translation>Использовать другие адреса интерфейса</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR</source>
+        <translation>IPv4 CIDR</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR</source>
+        <translation>IPv6 CIDR</translation>
+    </message>
+    <message>
+        <source>Invalid Tun Address</source>
+        <translation>Неверный адрес TUN</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR is invalid.</source>
+        <translation>Некорректный IPv4 CIDR.</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR is invalid.</source>
+        <translation>Некорректный IPv6 CIDR.</translation>
+    </message>
 </context>
 <context>
     <name>EditAdvanced</name>

--- a/res/translations/zh_CN.ts
+++ b/res/translations/zh_CN.ts
@@ -1195,8 +1195,8 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <translation>Tun 地址</translation>
     </message>
     <message>
-        <source>Use different interface addresses</source>
-        <translation>使用不同的接口地址</translation>
+        <source>Restore default addresses</source>
+        <translation>恢复默认地址</translation>
     </message>
     <message>
         <source>IPv4 CIDR</source>

--- a/res/translations/zh_CN.ts
+++ b/res/translations/zh_CN.ts
@@ -1190,6 +1190,34 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <source>Enable Tun Routing</source>
         <translation>启用 Tun 路由</translation>
     </message>
+    <message>
+        <source>Tun Address</source>
+        <translation>Tun 地址</translation>
+    </message>
+    <message>
+        <source>Use different interface addresses</source>
+        <translation>使用不同的接口地址</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR</source>
+        <translation>IPv4 CIDR</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR</source>
+        <translation>IPv6 CIDR</translation>
+    </message>
+    <message>
+        <source>Invalid Tun Address</source>
+        <translation>Tun 地址无效</translation>
+    </message>
+    <message>
+        <source>IPv4 CIDR is invalid.</source>
+        <translation>IPv4 CIDR 无效。</translation>
+    </message>
+    <message>
+        <source>IPv6 CIDR is invalid.</source>
+        <translation>IPv6 CIDR 无效。</translation>
+    </message>
 </context>
 <context>
     <name>EditAdvanced</name>

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -515,6 +515,7 @@ namespace Configs {
             const auto useCustomTunAddresses = Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses;
             const auto tunIPv4CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr : QString("172.19.0.1/24");
             const auto tunIPv6CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr : QString("fdfe:dcba:9876::1/96");
+            ctx->buildConfigResult->tunIPv4CIDR = tunIPv4CIDR;
             auto tunAddress = QJsonArray{tunIPv4CIDR};
             if (Configs::dataManager->settingsRepo->vpn_ipv6) tunAddress += tunIPv6CIDR;
             inboundObj["address"] = tunAddress;

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -512,9 +512,8 @@ namespace Configs {
             inboundObj["stack"] = Configs::dataManager->settingsRepo->vpn_implementation;
             inboundObj["strict_route"] = Configs::dataManager->settingsRepo->vpn_strict_route;
             if (ctx->os == Linux) inboundObj["auto_redirect"] = true;
-            const auto useCustomTunAddresses = Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses;
-            const auto tunIPv4CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr : QString("172.19.0.1/24");
-            const auto tunIPv6CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr : QString("fdfe:dcba:9876::1/96");
+            const auto tunIPv4CIDR = Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr;
+            const auto tunIPv6CIDR = Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr;
             ctx->buildConfigResult->tunIPv4CIDR = tunIPv4CIDR;
             auto tunAddress = QJsonArray{tunIPv4CIDR};
             if (Configs::dataManager->settingsRepo->vpn_ipv6) tunAddress += tunIPv6CIDR;

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -512,8 +512,11 @@ namespace Configs {
             inboundObj["stack"] = Configs::dataManager->settingsRepo->vpn_implementation;
             inboundObj["strict_route"] = Configs::dataManager->settingsRepo->vpn_strict_route;
             if (ctx->os == Linux) inboundObj["auto_redirect"] = true;
-            auto tunAddress = QJsonArray{"172.19.0.1/24"};
-            if (Configs::dataManager->settingsRepo->vpn_ipv6) tunAddress += "fdfe:dcba:9876::1/96";
+            const auto useCustomTunAddresses = Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses;
+            const auto tunIPv4CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr : QString("172.19.0.1/24");
+            const auto tunIPv6CIDR = useCustomTunAddresses ? Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr : QString("fdfe:dcba:9876::1/96");
+            auto tunAddress = QJsonArray{tunIPv4CIDR};
+            if (Configs::dataManager->settingsRepo->vpn_ipv6) tunAddress += tunIPv6CIDR;
             inboundObj["address"] = tunAddress;
 
             if (Configs::dataManager->settingsRepo->enable_tun_routing)
@@ -1143,4 +1146,3 @@ namespace Configs {
         return res;
     }
 }
-

--- a/src/database/SettingsRepo.cpp
+++ b/src/database/SettingsRepo.cpp
@@ -18,7 +18,6 @@ namespace Configs {
             "fakedns",
             "disable_traffic_stats",
             "vpn_ipv6",
-            "vpn_use_custom_interface_addresses",
             "vpn_strict_route",
             "sub_clear",
             "net_insecure",
@@ -313,7 +312,6 @@ namespace Configs {
                 else if (key == "vpn_impl") vpn_implementation = varValue.toString();
                 else if (key == "vpn_mtu") vpn_mtu = varValue.toInt();
                 else if (key == "vpn_ipv6") vpn_ipv6 = varValue.toBool();
-                else if (key == "vpn_use_custom_interface_addresses") vpn_use_custom_interface_addresses = varValue.toBool();
                 else if (key == "vpn_strict_route") vpn_strict_route = varValue.toBool();
                 else if (key == "vpn_tun_ipv4_cidr") vpn_tun_ipv4_cidr = varValue.toString();
                 else if (key == "vpn_tun_ipv6_cidr") vpn_tun_ipv6_cidr = varValue.toString();
@@ -440,7 +438,6 @@ namespace Configs {
             {"vpn_impl", vpn_implementation},
             {"vpn_mtu", vpn_mtu},
             {"vpn_ipv6", vpn_ipv6},
-            {"vpn_use_custom_interface_addresses", vpn_use_custom_interface_addresses},
             {"vpn_strict_route", vpn_strict_route},
             {"vpn_tun_ipv4_cidr", vpn_tun_ipv4_cidr},
             {"vpn_tun_ipv6_cidr", vpn_tun_ipv6_cidr},

--- a/src/database/SettingsRepo.cpp
+++ b/src/database/SettingsRepo.cpp
@@ -18,6 +18,7 @@ namespace Configs {
             "fakedns",
             "disable_traffic_stats",
             "vpn_ipv6",
+            "vpn_use_custom_interface_addresses",
             "vpn_strict_route",
             "sub_clear",
             "net_insecure",
@@ -105,6 +106,8 @@ namespace Configs {
             "active_routing",
             "mw_size",
             "vpn_impl",
+            "vpn_tun_ipv4_cidr",
+            "vpn_tun_ipv6_cidr",
             "sub_custom_hwid_params",
             "splitter_state",
             "utlsFingerprint",
@@ -310,7 +313,10 @@ namespace Configs {
                 else if (key == "vpn_impl") vpn_implementation = varValue.toString();
                 else if (key == "vpn_mtu") vpn_mtu = varValue.toInt();
                 else if (key == "vpn_ipv6") vpn_ipv6 = varValue.toBool();
+                else if (key == "vpn_use_custom_interface_addresses") vpn_use_custom_interface_addresses = varValue.toBool();
                 else if (key == "vpn_strict_route") vpn_strict_route = varValue.toBool();
+                else if (key == "vpn_tun_ipv4_cidr") vpn_tun_ipv4_cidr = varValue.toString();
+                else if (key == "vpn_tun_ipv6_cidr") vpn_tun_ipv6_cidr = varValue.toString();
                 else if (key == "disable_privilege_req") disable_privilege_req = varValue.toBool();
                 else if (key == "enable_ntp") enable_ntp = varValue.toBool();
                 else if (key == "ntp_server_address") ntp_server_address = varValue.toString();
@@ -434,7 +440,10 @@ namespace Configs {
             {"vpn_impl", vpn_implementation},
             {"vpn_mtu", vpn_mtu},
             {"vpn_ipv6", vpn_ipv6},
+            {"vpn_use_custom_interface_addresses", vpn_use_custom_interface_addresses},
             {"vpn_strict_route", vpn_strict_route},
+            {"vpn_tun_ipv4_cidr", vpn_tun_ipv4_cidr},
+            {"vpn_tun_ipv6_cidr", vpn_tun_ipv6_cidr},
             {"disable_privilege_req", disable_privilege_req},
             {"enable_ntp", enable_ntp},
             {"ntp_server_address", ntp_server_address},

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -681,6 +681,7 @@ void MainWindow::profile_start(int _id) {
     auto profile_start_stage2 = [=, this] {
         libcore::LoadConfigReq req;
         req.core_config = QJsonObject2QString(result->coreConfig, true).toStdString();
+        req.tun_ipv4_cidr = result->tunIPv4CIDR.toStdString();
         req.disable_stats = Configs::dataManager->settingsRepo->disable_traffic_stats;
         req.xray_config = QJsonObject2QString(result->xrayConfig, true).toStdString();
         req.need_xray = !result->xrayConfig.isEmpty();

--- a/src/ui/setting/dialog_vpn_settings.cpp
+++ b/src/ui/setting/dialog_vpn_settings.cpp
@@ -14,6 +14,9 @@
 #define ADJUST_SIZE runOnThread([=,this] { adjustSize(); adjustPosition(mainwindow); }, this);
 
 namespace {
+    const QString kDefaultTunIPv4CIDR = "172.19.0.1/24";
+    const QString kDefaultTunIPv6CIDR = "fdfe:dcba:9876::1/96";
+
     bool IsValidCIDR(const QString &cidr, const QAbstractSocket::NetworkLayerProtocol protocol) {
         const auto parts = cidr.trimmed().split("/");
         if (parts.size() != 2) return false;
@@ -54,15 +57,8 @@ DialogVPNSettings::DialogVPNSettings(QWidget *parent) : QDialog(parent), ui(new 
     ui->vpn_ipv6->setChecked(Configs::dataManager->settingsRepo->vpn_ipv6);
     ui->strict_route->setChecked(Configs::dataManager->settingsRepo->vpn_strict_route);
     ui->tun_routing->setChecked(Configs::dataManager->settingsRepo->enable_tun_routing);
-    ui->use_custom_interface_addresses->setChecked(Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses);
     ui->tun_ipv4_cidr->setText(Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr);
     ui->tun_ipv6_cidr->setText(Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr);
-    const auto updateAddressInputsState = [this](bool enabled) {
-        ui->tun_ipv4_cidr->setEnabled(enabled);
-        ui->tun_ipv6_cidr->setEnabled(enabled);
-    };
-    updateAddressInputsState(ui->use_custom_interface_addresses->isChecked());
-    connect(ui->use_custom_interface_addresses, &QCheckBox::toggled, this, updateAddressInputsState);
     ADJUST_SIZE
 }
 
@@ -74,14 +70,13 @@ void DialogVPNSettings::accept() {
     //
     auto mtu = ui->vpn_mtu->currentText().toInt();
     if (mtu > 10000 || mtu < 1000) mtu = 9000;
-    const auto useCustomTunAddresses = ui->use_custom_interface_addresses->isChecked();
     const auto tunIPv4CIDR = ui->tun_ipv4_cidr->text().trimmed();
     const auto tunIPv6CIDR = ui->tun_ipv6_cidr->text().trimmed();
-    if (useCustomTunAddresses && !IsValidCIDR(tunIPv4CIDR, QAbstractSocket::IPv4Protocol)) {
+    if (!IsValidCIDR(tunIPv4CIDR, QAbstractSocket::IPv4Protocol)) {
         QMessageBox::warning(this, tr("Invalid Tun Address"), tr("IPv4 CIDR is invalid."));
         return;
     }
-    if (useCustomTunAddresses && !IsValidCIDR(tunIPv6CIDR, QAbstractSocket::IPv6Protocol)) {
+    if (!IsValidCIDR(tunIPv6CIDR, QAbstractSocket::IPv6Protocol)) {
         QMessageBox::warning(this, tr("Invalid Tun Address"), tr("IPv6 CIDR is invalid."));
         return;
     }
@@ -91,7 +86,6 @@ void DialogVPNSettings::accept() {
     Configs::dataManager->settingsRepo->vpn_ipv6 = ui->vpn_ipv6->isChecked();
     Configs::dataManager->settingsRepo->vpn_strict_route = ui->strict_route->isChecked();
     Configs::dataManager->settingsRepo->enable_tun_routing = ui->tun_routing->isChecked();
-    Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses = useCustomTunAddresses;
     Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr = tunIPv4CIDR;
     Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr = tunIPv6CIDR;
     //
@@ -99,6 +93,11 @@ void DialogVPNSettings::accept() {
     msg << "VPNChanged";
     MW_dialog_message("", msg.join(","));
     QDialog::accept();
+}
+
+void DialogVPNSettings::on_restore_default_addresses_clicked() {
+    ui->tun_ipv4_cidr->setText(kDefaultTunIPv4CIDR);
+    ui->tun_ipv6_cidr->setText(kDefaultTunIPv6CIDR);
 }
 
 void DialogVPNSettings::on_troubleshooting_clicked() {

--- a/src/ui/setting/dialog_vpn_settings.cpp
+++ b/src/ui/setting/dialog_vpn_settings.cpp
@@ -8,9 +8,30 @@
 #endif
 
 #include <QMessageBox>
+#include <QHostAddress>
 
 
 #define ADJUST_SIZE runOnThread([=,this] { adjustSize(); adjustPosition(mainwindow); }, this);
+
+namespace {
+    bool IsValidCIDR(const QString &cidr, const QAbstractSocket::NetworkLayerProtocol protocol) {
+        const auto parts = cidr.trimmed().split("/");
+        if (parts.size() != 2) return false;
+
+        bool ok = false;
+        const int prefix = parts[1].toInt(&ok);
+        if (!ok) return false;
+
+        QHostAddress host;
+        if (!host.setAddress(parts[0].trimmed())) return false;
+        if (host.protocol() != protocol) return false;
+
+        if (protocol == QAbstractSocket::IPv4Protocol) return prefix >= 0 && prefix <= 32;
+        if (protocol == QAbstractSocket::IPv6Protocol) return prefix >= 0 && prefix <= 128;
+        return false;
+    }
+}
+
 DialogVPNSettings::DialogVPNSettings(QWidget *parent) : QDialog(parent), ui(new Ui::DialogVPNSettings) {
     ui->setupUi(this);
     ADD_ASTERISK(this);
@@ -33,6 +54,15 @@ DialogVPNSettings::DialogVPNSettings(QWidget *parent) : QDialog(parent), ui(new 
     ui->vpn_ipv6->setChecked(Configs::dataManager->settingsRepo->vpn_ipv6);
     ui->strict_route->setChecked(Configs::dataManager->settingsRepo->vpn_strict_route);
     ui->tun_routing->setChecked(Configs::dataManager->settingsRepo->enable_tun_routing);
+    ui->use_custom_interface_addresses->setChecked(Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses);
+    ui->tun_ipv4_cidr->setText(Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr);
+    ui->tun_ipv6_cidr->setText(Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr);
+    const auto updateAddressInputsState = [this](bool enabled) {
+        ui->tun_ipv4_cidr->setEnabled(enabled);
+        ui->tun_ipv6_cidr->setEnabled(enabled);
+    };
+    updateAddressInputsState(ui->use_custom_interface_addresses->isChecked());
+    connect(ui->use_custom_interface_addresses, &QCheckBox::toggled, this, updateAddressInputsState);
     ADJUST_SIZE
 }
 
@@ -44,11 +74,26 @@ void DialogVPNSettings::accept() {
     //
     auto mtu = ui->vpn_mtu->currentText().toInt();
     if (mtu > 10000 || mtu < 1000) mtu = 9000;
+    const auto useCustomTunAddresses = ui->use_custom_interface_addresses->isChecked();
+    const auto tunIPv4CIDR = ui->tun_ipv4_cidr->text().trimmed();
+    const auto tunIPv6CIDR = ui->tun_ipv6_cidr->text().trimmed();
+    if (useCustomTunAddresses && !IsValidCIDR(tunIPv4CIDR, QAbstractSocket::IPv4Protocol)) {
+        QMessageBox::warning(this, tr("Invalid Tun Address"), tr("IPv4 CIDR is invalid."));
+        return;
+    }
+    if (useCustomTunAddresses && !IsValidCIDR(tunIPv6CIDR, QAbstractSocket::IPv6Protocol)) {
+        QMessageBox::warning(this, tr("Invalid Tun Address"), tr("IPv6 CIDR is invalid."));
+        return;
+    }
+
     Configs::dataManager->settingsRepo->vpn_implementation = ui->vpn_implementation->currentText();
     Configs::dataManager->settingsRepo->vpn_mtu = mtu;
     Configs::dataManager->settingsRepo->vpn_ipv6 = ui->vpn_ipv6->isChecked();
     Configs::dataManager->settingsRepo->vpn_strict_route = ui->strict_route->isChecked();
     Configs::dataManager->settingsRepo->enable_tun_routing = ui->tun_routing->isChecked();
+    Configs::dataManager->settingsRepo->vpn_use_custom_interface_addresses = useCustomTunAddresses;
+    Configs::dataManager->settingsRepo->vpn_tun_ipv4_cidr = tunIPv4CIDR;
+    Configs::dataManager->settingsRepo->vpn_tun_ipv6_cidr = tunIPv6CIDR;
     //
     QStringList msg{"UpdateConfigs::dataManager->settingsRepo"};
     msg << "VPNChanged";


### PR DESCRIPTION
Adds two inputs to the TUN configuration dialog, for IPv4 and IPv6 CIDR's respectively + a button which resets CIDR values to the default ones. Tested everything on Linux (CachyOS), so far it works fine. I did use an agent for this but I checked all the code myself as well (and did some manual fixes in the go part). So far it looks and works fine.