### PR TITLE
Support chain profiles as routing outbounds

### DIFF
--- a/include/configs/generate.h
+++ b/include/configs/generate.h
@@ -47,9 +47,12 @@ namespace Configs
     {
         public:
         int defaultOutboundID;
-        QList<int> neededOutbounds;
+        QList<int> neededOutbounds;       // kept for compatibility but no longer consumed
         QStringList neededRuleSets;
         std::map<int, QString> outboundMap;
+        // Each entry is one routing outbound group.
+        // Single profile -> [[id]]. Chain -> [[outerHop, ..., innerHop]] (reversed, matching existing chain build order).
+        QList<QList<int>> routeOutboundGroups;
     };
 
     class BuildPrerequisities

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -132,25 +132,58 @@ namespace Configs {
             if (item < 0) continue;
             auto neededEnt = Configs::dataManager->profilesRepo->GetProfile(item);
             if (neededEnt == nullptr) {
-                ctx->error = "The routing profile is referencing outbounds that no longer exists, consider revising your settings";
+                ctx->error = "The routing profile is referencing outbounds that no longer exist, consider revising your settings";
                 return;
             }
-            if (neededEnt->type == "extracore" || neededEnt->type == "custom" || neededEnt->type == "chain")
-            {
-                ctx->error = "Outbounds used in routing profile cannot be of types extracore, custom or chain";
+            if (neededEnt->type == "extracore" || neededEnt->type == "custom") {
+                ctx->error = "Outbounds used in routing profile cannot be of types extracore or custom";
                 return;
             }
-            if (auto entAddrs = getEntDomains({neededEnt->id}, ctx->error); !entAddrs.empty())
-            {
-                if (!ctx->error.isEmpty()) return;
-                for (const auto &addr: entAddrs)
-                {
-                    preReqs->dnsDeps->directDomains << addr;
+            if (neededEnt->type == "chain") {
+                auto chain = neededEnt->Chain();
+                if (chain == nullptr || chain->list.isEmpty()) {
+                    ctx->error = "Chain outbound in routing profile is empty or corrupted";
+                    return;
                 }
-                preReqs->dnsDeps->needDirectDnsRules = true;
+                // Validate each hop
+                for (int hopID : chain->list) {
+                    auto hopEnt = Configs::dataManager->profilesRepo->GetProfile(hopID);
+                    if (hopEnt == nullptr) {
+                        ctx->error = "Chain outbound in routing profile contains a missing profile";
+                        return;
+                    }
+                    if (hopEnt->type == "extracore" || hopEnt->type == "custom" || hopEnt->type == "chain") {
+                        ctx->error = "Chain hops in routing profile cannot be of types extracore, custom or chain";
+                        return;
+                    }
+                    // Collect domains for DNS direct rules
+                    if (auto addrs = getEntDomains({hopID}, ctx->error); !addrs.empty()) {
+                        if (!ctx->error.isEmpty()) return;
+                        for (const auto &addr : addrs) preReqs->dnsDeps->directDomains << addr;
+                        preReqs->dnsDeps->needDirectDnsRules = true;
+                    }
+                }
+                // Map chain ID -> tag of the outermost (first-built) hop
+                preReqs->routingDeps->outboundMap[item] = "route-" + Int2String(suffix);
+                // Build reversed hop list (matching main-chain build order: outer first)
+                QList<int> reversedHops;
+                for (int idx = chain->list.size() - 1; idx >= 0; idx--) reversedHops << chain->list[idx];
+                preReqs->routingDeps->routeOutboundGroups << reversedHops;
+                suffix += chain->list.size();
+            } else {
+                // Single-hop outbound (existing logic)
+                if (auto entAddrs = getEntDomains({neededEnt->id}, ctx->error); !entAddrs.empty())
+                {
+                    if (!ctx->error.isEmpty()) return;
+                    for (const auto &addr: entAddrs)
+                    {
+                        preReqs->dnsDeps->directDomains << addr;
+                    }
+                    preReqs->dnsDeps->needDirectDnsRules = true;
+                }
+                preReqs->routingDeps->outboundMap[item] = "route-" + Int2String(suffix++);
+                preReqs->routingDeps->routeOutboundGroups << QList<int>{item};
             }
-            preReqs->routingDeps->outboundMap[item] = "route-" + Int2String(suffix++);
-            preReqs->routingDeps->neededOutbounds << item;
         }
 
         for (const auto &item: *neededRuleSets) {
@@ -609,15 +642,15 @@ namespace Configs {
         return {entID};
     }
 
-    void buildOutboundChain(std::shared_ptr<BuildSingBoxConfigContext> &ctx, const QList<int>& entIDs, const QString& prefix, bool includeProxy, bool link, int xrayPort = -1)
+    void buildOutboundChain(std::shared_ptr<BuildSingBoxConfigContext> &ctx, const QList<int>& entIDs, const QString& prefix, bool includeProxy, bool link, int xrayPort = -1, int startSuffix = 0)
     {
         QList<std::shared_ptr<Profile>> ents;
         entIDListtoEntList(entIDs, ents, ctx->error);
         for (int idx = 0; idx < ents.size(); idx++)
         {
-            auto tag = prefix + "-" + Int2String(idx);
+            auto tag = prefix + "-" + Int2String(startSuffix + idx);
             QString nextTag;
-            if (idx < ents.size() - 1) nextTag = prefix + "-" + Int2String(idx+1);
+            if (idx < ents.size() - 1) nextTag = prefix + "-" + Int2String(startSuffix + idx + 1);
             if (includeProxy && idx == 0) tag = "proxy";
             const auto& ent = ents[idx];
             auto [object, error] = ent->outbound->Build();
@@ -681,7 +714,12 @@ namespace Configs {
         buildOutboundChain(ctx, entIDs, "config", true, true);
 
         // Now, build the outbounds needed by the route profile
-        buildOutboundChain(ctx, ctx->buildPrerequisities->routingDeps->neededOutbounds, "route", false, false);
+        int routeSuffix = 0;
+        for (const auto& group : ctx->buildPrerequisities->routingDeps->routeOutboundGroups) {
+            bool linked = group.size() > 1;
+            buildOutboundChain(ctx, group, "route", false, linked, -1, routeSuffix);
+            routeSuffix += group.size();
+        }
 
         // Add the direct outbound
         ctx->outbounds.append(QJsonObject{


### PR DESCRIPTION
### Problem
Routing rules can reference a specific outbound profile. If that profile is of type chain (e.g. VLESS -> WireGuard), the config builder currently hard-rejects it: "Outbounds used in routing profile cannot be of types extracore, custom or chain"

### Solution
`CalculatePrerequisities` now expands chain profiles instead of rejecting them. Each hop is validated, DNS domains are collected from all hops, and the chain is stored as a reversed hop group in the new `routeOutboundGroups` field.
`buildOutboundsSection` iterates these groups. Multi-hop groups are built with `link=true` so the detour chain is wired up, using a `startSuffix` offset (new optional parameter on `buildOutboundChain`, default `0`) to keep route tags globally unique across multiple groups.

### What is NOT changed
- `extracore` and `custom` remain rejected in routing
- Nested chains (chain-in-chain hops) are rejected at hop validation
- All existing call sites of `buildOutboundChain` are unaffected (default `startSuffix=0`)
- `BuildTestConfig` is unchanged