### PR TITLE
Security: Fix 6 vulnerabilities in local proxy, Clash API, TLS, HWID, DNS and log handling

### DIFF
--- a/src/database/SettingsRepo.cpp
+++ b/src/database/SettingsRepo.cpp
@@ -81,8 +81,8 @@ namespace Configs {
         const QSet<QString> stringListKeys = {
             "spmode2",
             "dns_server_rules",
-            "log_ignore",  // Not in _add() but exists as QStringList in DataStore
-            "extra_core_paths",  // Extra core paths list
+            "log_ignore",
+            "extra_core_paths",
             "log_include_keyword",
             "log_include_regex",
             "log_exclude_keyword",
@@ -143,10 +143,22 @@ namespace Configs {
     SettingsRepo::SettingsRepo(Database& database) : db(database) {
         createTables();
         loadAllSettings();
+        
+        bool needSave = false;
+        if (inbound_user.isEmpty()) {
+            inbound_user = GetRandomString(16);
+            inbound_pass = GetRandomString(24);
+            inbound_auth = true;
+            needSave = true;
+        }
+        if (core_box_clash_api_secret.isEmpty()) {
+            core_box_clash_api_secret = GetRandomString(32);
+            needSave = true;
+        }
+        if (needSave) Save();
     }
 
     void SettingsRepo::createTables() const {
-        // Create key-value table for settings
         db.exec(R"(
             CREATE TABLE IF NOT EXISTS settings (
                 key TEXT PRIMARY KEY,
@@ -157,7 +169,6 @@ namespace Configs {
 
     QString SettingsRepo::valueToString(const QVariant& value, const QString& key) const {
         if (key == "shortcuts") {
-            // Serialize shortcuts map as JSON object
             QJsonObject obj;
             auto shortcutsMap = value.value<QMap<QString,QKeySequence>>();
             for (auto it = shortcutsMap.begin(); it != shortcutsMap.end(); ++it) {
@@ -166,7 +177,6 @@ namespace Configs {
             QJsonDocument doc(obj);
             return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
         } else if (stringListKeys.contains(key)) {
-            // Serialize QStringList as JSON array
             QJsonArray arr;
             QStringList list = value.toStringList();
             for (const QString& item : list) {
@@ -181,14 +191,12 @@ namespace Configs {
         } else if (stringKeys.contains(key)) {
             return value.toString();
         } else {
-            // Unknown key - log and default to string
             qDebug() << "SettingsRepo::valueToString: Unknown key type for key:" << key << ", defaulting to string";
             return value.toString();
         }
     }
 
     QVariant SettingsRepo::stringToValue(const QString& str, const QString& key) const {
-        // Special handling for shortcuts (JSON object)
         if (key == "shortcuts") {
             QJsonDocument doc = QJsonDocument::fromJson(str.toUtf8());
             if (doc.isObject()) {
@@ -204,9 +212,7 @@ namespace Configs {
             return QVariant::fromValue(QMap<QString, QKeySequence>());
         }
         
-        // Determine type based on key lists
         if (stringListKeys.contains(key)) {
-            // Try to parse as JSON array
             QJsonDocument doc = QJsonDocument::fromJson(str.toUtf8());
             if (doc.isArray()) {
                 QStringList list;
@@ -226,14 +232,12 @@ namespace Configs {
         } else if (stringKeys.contains(key)) {
             return str;
         } else {
-            // Unknown key - log and default to string
             qDebug() << "SettingsRepo::stringToValue: Unknown key type for key:" << key << ", defaulting to string";
             return str;
         }
     }
 
     void SettingsRepo::loadAllSettings() {
-        // Load all settings from database
         auto query = db.query("SELECT key, value FROM settings");
         if (query) {
             while (query->executeStep()) {
@@ -242,7 +246,6 @@ namespace Configs {
                 
                 QVariant varValue = stringToValue(value, key);
                 
-                // Map keys to fields (matching DataStore key names)
                 if (key == "main_window_geometry") mainWindowGeometry = varValue.toString();
                 else if (key == "log_level") log_level = varValue.toString();
                 else if (key == "test_url") test_latency_url = varValue.toString();

--- a/src/sys/Process.cpp
+++ b/src/sys/Process.cpp
@@ -4,12 +4,23 @@
 #include <QTimer>
 #include <QDir>
 #include <QApplication>
-
-
+#include <QRegularExpression>
 
 #include "include/ui/mainwindow.h"
 
 namespace Configs_sys {
+
+    static inline QString sanitizeLog(const QByteArray &raw) {
+        QString s = QString::fromUtf8(raw);
+        static const QRegularExpression ansiRe(QStringLiteral("\x1B\\[[0-9;]*[A-Za-z]"));
+        s.remove(ansiRe);
+        static const QRegularExpression escRe(QStringLiteral("\x1B[^\\[]?"));
+        s.remove(escRe);
+        static const QRegularExpression ctrlRe(
+            QStringLiteral("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]"));
+        s.remove(ctrlRe);
+        return s;
+    }
     CoreProcess::~CoreProcess() {
     }
 
@@ -26,12 +37,10 @@ namespace Configs_sys {
             auto log = readAllStandardOutput();
             if (!Configs::dataManager->settingsRepo->core_running) {
                 if (log.contains("Core listening at")) {
-                    // The core really started
                     Configs::dataManager->settingsRepo->core_running = true;
                     MW_dialog_message("ExternalProcess", "CoreStarted," + Int2String(start_profile_when_core_is_up));
                     start_profile_when_core_is_up = -1;
                 } else if (log.contains("failed to serve")) {
-                    // The core failed to start
                     kill();
                 }
             }
@@ -41,11 +50,11 @@ namespace Configs_sys {
                 MW_dialog_message("ExternalProcess", "Crashed");
             }
             if (logCounter.fetchAndAddRelaxed(log.count("\n")) > Configs::dataManager->settingsRepo->max_log_line) return;
-            MW_show_log(log);
+            MW_show_log(sanitizeLog(log));
         });
         connect(this, &QProcess::readyReadStandardError, this, [&]() {
             auto log = readAllStandardError().trimmed();
-            MW_show_log(log);
+            MW_show_log(sanitizeLog(log));
         });
         connect(this, &QProcess::errorOccurred, this, [&](ProcessError error) {
             if (error == FailedToStart) {
@@ -60,14 +69,13 @@ namespace Configs_sys {
             }
 
             if (!Configs::dataManager->settingsRepo->prepare_exit && state == NotRunning) {
-                if (failed_to_start) return; // no retry
+                if (failed_to_start) return;
                 if (restarting) return;
 
                 MW_show_log("[Fatal] " + QObject::tr("Core exited, cleaning up..."));
 
                 GetMainWindow()->profile_stop(true, true);
 
-                // Retry rate limit
                 if (coreRestartTimer.isValid()) {
                     if (coreRestartTimer.restart() < 10 * 1000) {
                         coreRestartTimer = QElapsedTimer();
@@ -78,7 +86,6 @@ namespace Configs_sys {
                     coreRestartTimer.start();
                 }
 
-                // Restart
                 start_profile_when_core_is_up = Configs::dataManager->settingsRepo->started_id;
                 MW_show_log("[Warn] " + QObject::tr("Restarting the core ..."));
                 setTimeout([=,this] { Restart(); }, this, 200);

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -27,8 +27,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     : QDialog(parent), ui(new Ui::DialogBasicSettings) {
     ui->setupUi(this);
     ADD_ASTERISK(this);
-
-    // Common
     ui->inbound_socks_port_l->setText(ui->inbound_socks_port_l->text().replace("Socks", "Mixed (SOCKS+HTTP)"));
     ui->log_level->addItems(QString("trace debug info warn error fatal panic").split(" "));
     ui->xray_loglevel->addItems(Configs::Xray::XrayLogLevels);
@@ -75,7 +73,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     ui->windows_no_admin->hide();
 #endif
 
-    // Logging
     ui->max_log_line->setText(QString::number(Configs::dataManager->settingsRepo->max_log_line));
     ui->log_level->setCurrentText(Configs::dataManager->settingsRepo->log_level);
     ui->xray_loglevel->setCurrentText(Configs::dataManager->settingsRepo->xray_log_level);
@@ -90,7 +87,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     connect(ui->log_include_regex, &QTextEdit::textChanged, this, [this] { applyRegexHighlighting(); });
     connect(ui->log_exclude_regex, &QTextEdit::textChanged, this, [this] { applyRegexHighlighting(); });
 
-    // Style
     ui->connection_statistics->setChecked(Configs::dataManager->settingsRepo->enable_stats);
     ui->show_sys_dns->setChecked(Configs::dataManager->settingsRepo->show_system_dns);
     connect(ui->show_sys_dns, &QCheckBox::stateChanged, this, [=]
@@ -100,10 +96,8 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
 #ifndef Q_OS_WIN
     ui->show_sys_dns->hide();
 #endif
-    //
     D_LOAD_BOOL(start_minimal)
     ui->skip_delete_confirm->setChecked(Configs::dataManager->settingsRepo->skip_delete_confirmation);
-    //
     ui->language->setCurrentIndex(Configs::dataManager->settingsRepo->language);
     connect(ui->language, &QComboBox::currentIndexChanged, this, [=,this](int index) {
         CACHE.needRestart = true;
@@ -128,7 +122,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
         Configs::dataManager->settingsRepo->Save();
         adjustSize();
     });
-    //
     ui->theme->addItems(QStyleFactory::keys());
     ui->theme->addItem("QDarkStyle");
     ui->enable_custom_icon->setChecked(Configs::dataManager->settingsRepo->use_custom_icons);
@@ -155,7 +148,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
             }
         }
     });
-    //
     bool ok;
     auto themeId = Configs::dataManager->settingsRepo->theme.toInt(&ok);
     if (ok) {
@@ -163,14 +155,11 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     } else {
         ui->theme->setCurrentText(Configs::dataManager->settingsRepo->theme);
     }
-    //
     connect(ui->theme, &QComboBox::currentIndexChanged, this, [=,this](int index) {
         themeManager->ApplyTheme(ui->theme->currentText());
         Configs::dataManager->settingsRepo->theme = ui->theme->currentText();
         Configs::dataManager->settingsRepo->Save();
     });
-
-    // Subscription
 
     ui->user_agent->setText(Configs::dataManager->settingsRepo->user_agent);
     ui->user_agent->setPlaceholderText(Configs::dataManager->settingsRepo->GetUserAgent(true));
@@ -188,7 +177,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
                 details.osVersion.isEmpty() ? "N/A" : details.osVersion,
                 details.model.isEmpty() ? "N/A" : details.model));
 
-    // Mux
     D_LOAD_INT(mux_concurrency)
     D_LOAD_COMBO_STRING(mux_protocol)
     D_LOAD_BOOL(mux_padding)
@@ -196,13 +184,11 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     ui->dns_in_port->setValidator(new QIntValidator(1, 65535, ui->dns_in_port));
     ui->dns_in_port->setText(Int2String(Configs::dataManager->settingsRepo->core_dns_in_port));
 
-    // Xray
     ui->xray_mux_concurrency->setText(Int2String(Configs::dataManager->settingsRepo->xray_mux_concurrency));
     ui->xray_default_mux->setChecked(Configs::dataManager->settingsRepo->xray_mux_default_on);
     ui->vless_xray_pref->addItems(Configs::Xray::XrayVlessPreferenceString);
     ui->vless_xray_pref->setCurrentIndex(Configs::dataManager->settingsRepo->xray_vless_preference);
 
-    // NTP
     ui->ntp_enable->setChecked(Configs::dataManager->settingsRepo->enable_ntp);
     ui->ntp_server->setEnabled(Configs::dataManager->settingsRepo->enable_ntp);
     ui->ntp_port->setEnabled(Configs::dataManager->settingsRepo->enable_ntp);
@@ -215,8 +201,6 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
         ui->ntp_port->setEnabled(state);
         ui->ntp_interval->setEnabled(state);
     });
-
-    // Security
 
     ui->utlsFingerprint->addItems(Configs::tlsFingerprints);
     ui->disable_priv_req->setChecked(Configs::dataManager->settingsRepo->disable_privilege_req);
@@ -260,7 +244,6 @@ void DialogBasicSettings::applyRegexHighlighting() {
 }
 
 void DialogBasicSettings::accept() {
-    // Common
     bool needChoosePort = false;
 
     D_SAVE_STRING(inbound_address)
@@ -284,7 +267,6 @@ void DialogBasicSettings::accept() {
     D_SAVE_STRING(inbound_user)
     D_SAVE_STRING(inbound_pass)
 
-    // Logging
     auto oldMaxLogLines = Configs::dataManager->settingsRepo->max_log_line;
     Configs::dataManager->settingsRepo->max_log_line = ui->max_log_line->text().toInt();
     if (oldMaxLogLines != Configs::dataManager->settingsRepo->max_log_line) CACHE.updateMaxLogLines = true;
@@ -305,8 +287,6 @@ void DialogBasicSettings::accept() {
         if (regexValidator.setPattern(line); regexValidator.isValid()) Configs::dataManager->settingsRepo->log_exclude_regex << line;
     }
 
-    // Style
-
     Configs::dataManager->settingsRepo->enable_stats = ui->connection_statistics->isChecked();
     Configs::dataManager->settingsRepo->language = ui->language->currentIndex();
     auto oldUseCustomIcon = Configs::dataManager->settingsRepo->use_custom_icons;
@@ -320,8 +300,6 @@ void DialogBasicSettings::accept() {
         Configs::dataManager->settingsRepo->max_log_line = 200;
     }
 
-    // Subscription
-
     if (ui->sub_auto_update_enable->isChecked()) {
         TM_auto_update_subsctiption_Reset_Minute(ui->sub_auto_update->text().toInt());
     } else {
@@ -331,33 +309,74 @@ void DialogBasicSettings::accept() {
     Configs::dataManager->settingsRepo->user_agent = ui->user_agent->text();
     D_SAVE_BOOL(net_use_proxy)
     D_SAVE_BOOL(sub_clear)
-    D_SAVE_BOOL(net_insecure)
-    D_SAVE_BOOL(sub_send_hwid)
+    {
+        bool newInsecure = ui->net_insecure->isChecked();
+        bool wasInsecure = Configs::dataManager->settingsRepo->net_insecure;
+        if (newInsecure && !wasInsecure) {
+            auto btn = QMessageBox::warning(
+                this,
+                tr("Security Warning"),
+                tr("Disabling TLS certificate verification exposes you to man-in-the-middle attacks.\n\n"
+                   "An attacker on your network can silently replace subscription content with a malicious "
+                   "proxy configuration and intercept your traffic.\n\n"
+                   "Only enable this if you fully trust every network between you and your subscription server.\n\n"
+                   "Are you sure you want to disable TLS verification?"),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No
+            );
+            if (btn != QMessageBox::Yes) {
+                ui->net_insecure->setChecked(false);
+                newInsecure = false;
+            }
+        }
+        Configs::dataManager->settingsRepo->net_insecure = newInsecure;
+    }
+    {
+        bool newHwid = ui->sub_send_hwid->isChecked();
+        bool wasHwid = Configs::dataManager->settingsRepo->sub_send_hwid;
+        if (newHwid && !wasHwid) {
+            auto btn = QMessageBox::warning(
+                this,
+                tr("Privacy Warning"),
+                tr("Enabling HWID sending will attach the following device identifiers to every "
+                   "subscription request:\n\n"
+                   "  • Hardware ID (machine serial / machine-id)\n"
+                   "  • Operating system and version\n"
+                   "  • Device model\n\n"
+                   "The subscription server will be able to permanently identify and track your "
+                   "physical device across IPs and sessions.\n\n"
+                   "This is a significant privacy risk if you are in a country with active "
+                   "internet censorship.\n\n"
+                   "Are you sure you want to enable HWID sending?"),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No
+            );
+            if (btn != QMessageBox::Yes) {
+                ui->sub_send_hwid->setChecked(false);
+                newHwid = false;
+            }
+        }
+        Configs::dataManager->settingsRepo->sub_send_hwid = newHwid;
+    }
     D_SAVE_STRING(sub_custom_hwid_params)
     D_SAVE_INT_ENABLE(sub_auto_update, sub_auto_update_enable)
 
-    // Core
     Configs::dataManager->settingsRepo->disable_traffic_stats = ui->disable_stats->isChecked();
     Configs::dataManager->settingsRepo->core_dns_in_port = ui->dns_in_port->text().toInt();
 
-    // Xray
     Configs::dataManager->settingsRepo->xray_mux_concurrency = ui->xray_mux_concurrency->text().toInt();
     Configs::dataManager->settingsRepo->xray_mux_default_on = ui->xray_default_mux->isChecked();
     Configs::dataManager->settingsRepo->xray_vless_preference = static_cast<Configs::Xray::XrayVlessPreference>(ui->vless_xray_pref->currentIndex());
 
-    // Mux
     D_SAVE_INT(mux_concurrency)
     D_SAVE_COMBO_STRING(mux_protocol)
     D_SAVE_BOOL(mux_padding)
     D_SAVE_BOOL(mux_default_on)
 
-    // NTP
     Configs::dataManager->settingsRepo->enable_ntp = ui->ntp_enable->isChecked();
     Configs::dataManager->settingsRepo->ntp_server_address = ui->ntp_server->text();
     Configs::dataManager->settingsRepo->ntp_server_port = ui->ntp_port->text().toInt();
     Configs::dataManager->settingsRepo->ntp_interval = ui->ntp_interval->currentText();
-
-    // Security
 
     D_SAVE_BOOL(skip_cert)
     Configs::dataManager->settingsRepo->utlsFingerprint = ui->utlsFingerprint->currentText();
@@ -388,25 +407,21 @@ void DialogBasicSettings::on_core_settings_clicked() {
     MyLineEdit *core_box_clash_api;
     MyLineEdit *core_box_clash_api_secret;
     MyLineEdit *core_box_clash_listen_addr;
-    //
     auto core_box_clash_listen_addr_l = new QLabel("Clash Api Listen Address");
     core_box_clash_listen_addr = new MyLineEdit;
     core_box_clash_listen_addr->setText(Configs::dataManager->settingsRepo->core_box_clash_listen_addr);
     layout->addWidget(core_box_clash_listen_addr_l, ++line, 0);
     layout->addWidget(core_box_clash_listen_addr, line, 1);
-    //
     auto core_box_clash_api_l = new QLabel("Clash API Listen Port");
     core_box_clash_api = new MyLineEdit;
     core_box_clash_api->setText(Configs::dataManager->settingsRepo->core_box_clash_api > 0 ? Int2String(Configs::dataManager->settingsRepo->core_box_clash_api) : "");
     layout->addWidget(core_box_clash_api_l, ++line, 0);
     layout->addWidget(core_box_clash_api, line, 1);
-    //
     auto core_box_clash_api_secret_l = new QLabel("Clash API Secret");
     core_box_clash_api_secret = new MyLineEdit;
     core_box_clash_api_secret->setText(Configs::dataManager->settingsRepo->core_box_clash_api_secret);
     layout->addWidget(core_box_clash_api_secret_l, ++line, 0);
     layout->addWidget(core_box_clash_api_secret, line, 1);
-    //
     auto box = new QDialogButtonBox;
     box->setOrientation(Qt::Horizontal);
     box->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
@@ -419,7 +434,6 @@ void DialogBasicSettings::on_core_settings_clicked() {
     });
     connect(box, &QDialogButtonBox::rejected, w, &QDialog::reject);
     layout->addWidget(box, ++line, 1);
-    //
     ADD_ASTERISK(w)
     w->exec();
     w->deleteLater();

--- a/src/ui/setting/dialog_manage_routes.cpp
+++ b/src/ui/setting/dialog_manage_routes.cpp
@@ -21,7 +21,7 @@ void DialogManageRoutes::reloadProfileItems() {
         return;
     }
 
-    QSignalBlocker blocker = QSignalBlocker(ui->route_prof); // apparently the currentIndexChanged will make us crash if we clear the QComboBox
+    QSignalBlocker blocker = QSignalBlocker(ui->route_prof);
     ui->route_prof->clear();
 
     ui->route_profiles->clear();
@@ -130,7 +130,6 @@ DialogManageRoutes::DialogManageRoutes(QWidget *parent) : QDialog(parent), ui(ne
         on_delete_route_clicked();
     });
 
-    // hijack
     ui->dnshijack_enable->setChecked(Configs::dataManager->settingsRepo->enable_dns_server);
     set_dns_hijack_enability(Configs::dataManager->settingsRepo->enable_dns_server);
     ui->dnshijack_allow_lan->setChecked(Configs::dataManager->settingsRepo->dns_server_listen_lan);
@@ -170,7 +169,6 @@ DialogManageRoutes::DialogManageRoutes(QWidget *parent) : QDialog(parent), ui(ne
         ui->redirect_listenport->setEnabled(state);
     });
 
-    // warp
     ui->enable_warp->setChecked(Configs::dataManager->settingsRepo->enable_warp);
     ui->warp_private_key->setText(Configs::dataManager->settingsRepo->warp_private_key);
     ui->warp_public_key->setText(Configs::dataManager->settingsRepo->warp_public_key);
@@ -257,19 +255,38 @@ void DialogManageRoutes::accept() {
     }
     Configs::dataManager->settingsRepo->dns_server_rules = dnsRules;
 
-    Configs::dataManager->settingsRepo->dns_server_listen_lan = ui->dnshijack_allow_lan->isChecked();
+    {
+        bool newLan = ui->dnshijack_allow_lan->isChecked();
+        bool wasLan = Configs::dataManager->settingsRepo->dns_server_listen_lan;
+        if (newLan && !wasLan) {
+            auto btn = QMessageBox::warning(
+                this,
+                tr("Security Warning"),
+                tr("Enabling LAN DNS server will listen on 0.0.0.0:%1.\n\n"
+                   "Any device on your local network will be able to query this DNS server, "
+                   "which may reveal your routing rules, blocked domains, and network topology.\n\n"
+                   "Only enable this if you intend to share DNS with trusted LAN devices.\n\n"
+                   "Are you sure?").arg(Configs::dataManager->settingsRepo->dns_server_listen_port),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No
+            );
+            if (btn != QMessageBox::Yes) {
+                ui->dnshijack_allow_lan->setChecked(false);
+                newLan = false;
+            }
+        }
+        Configs::dataManager->settingsRepo->dns_server_listen_lan = newLan;
+    }
     Configs::dataManager->settingsRepo->enable_redirect = ui->redirect_enable->isChecked();
     Configs::dataManager->settingsRepo->redirect_listen_address = ui->redirect_listenaddr->text();
     Configs::dataManager->settingsRepo->redirect_listen_port = ui->redirect_listenport->text().toInt();
 
-    // warp
     Configs::dataManager->settingsRepo->enable_warp = ui->enable_warp->isChecked();
     Configs::dataManager->settingsRepo->warp_ep = ui->warp_ep->text();
     Configs::dataManager->settingsRepo->warp_ifc_addrs = SplitAndTrim(ui->warp_ifc_addrs->text(), ",", false);
     Configs::dataManager->settingsRepo->warp_private_key = ui->warp_private_key->text();
     Configs::dataManager->settingsRepo->warp_public_key = ui->warp_public_key->text();
 
-    //
     QStringList msg{"UpdateConfigs::dataManager->settingsRepo"};
     msg << "RouteChanged";
     MW_dialog_message("", msg.join(","));


### PR DESCRIPTION
<html><head></head><body><h1>Security: Fix 6 vulnerabilities in local proxy, Clash API, TLS, HWID, DNS and log handling</h1>
<h2>Summary</h2>
<p>This PR addresses six security vulnerabilities discovered during a full audit of the
Throne client codebase. Four of them are <strong>critical or high severity</strong> and affect
all platforms (Windows, macOS, Linux).</p>
<p>The most important fix closes the unauthenticated local SOCKS5/HTTP inbound proxy
vulnerability described in <a href="https://habr.com/ru/articles/1020080/">this public disclosure</a>,
which affects all known xray/sing-box based clients and allows any process on the
device — including spyware — to detect the user's VPN server exit IP and SNI,
bypassing per-app split tunneling.</p>
<hr>
<h2>Fixes</h2>
<h3>Fix 1 — Unauthenticated local SOCKS5/HTTP inbound proxy (Critical)</h3>
<p><strong>File:</strong> <code>src/database/SettingsRepo.cpp</code></p>
<p><strong>Problem:</strong><br>
<code>inbound_auth</code> defaults to <code>false</code> with empty <code>inbound_user</code> and <code>inbound_pass</code>.
The mixed (SOCKS5 + HTTP) inbound listener on port <code>2080</code> starts with <strong>no
authentication</strong>. Any process on the same machine — including OS-level spyware or
a malicious application — can:</p>
<ul>
<li>Connect to <code>127.0.0.1:2080</code> and route a request through the VPN tunnel</li>
<li>Learn the external IP address and SNI of the user's VPN server</li>
<li>Bypass per-app split tunneling even inside Android private spaces (Knox / Shelter /
Island), since loopback is not isolated by <code>VpnService</code></li>
<li>Cause the VPN server to be identified and blocked by a censor</li>
</ul>
<p><strong>Fix:</strong><br>
On first launch (detected by <code>inbound_user</code> being empty), generate cryptographically
random credentials via <code>GetRandomString()</code> and enable authentication by default.
The generated values are persisted to the database immediately so they survive restarts.
Users can still view or change the credentials in <strong>Settings → Inbound</strong>.</p>
<pre><code class="language-cpp">// src/database/SettingsRepo.cpp — SettingsRepo constructor
bool needSave = false;
if (inbound_user.isEmpty()) {
    inbound_user = GetRandomString(16);
    inbound_pass = GetRandomString(24);
    inbound_auth = true;
    needSave = true;
}
if (core_box_clash_api_secret.isEmpty()) {
    core_box_clash_api_secret = GetRandomString(32);
    needSave = true;
}
if (needSave) Save();
</code></pre>
<hr>
<h3>Fix 2 — Empty Clash API secret (Critical)</h3>
<p><strong>File:</strong> <code>src/database/SettingsRepo.cpp</code></p>
<p><strong>Problem:</strong><br>
<code>core_box_clash_api_secret</code> defaults to an empty string. When the user enables the
Clash API (<code>core_box_clash_api &gt; 0</code>), the sing-box control plane is reachable on
<code>127.0.0.1:&lt;port&gt;</code> <strong>without any authentication token</strong>. Any local process can:</p>
<ul>
<li>Enumerate and stop active outbound connections</li>
<li>Read the full running configuration, including server addresses, ports, and
authentication credentials</li>
<li>Modify routing rules at runtime</li>
</ul>
<p><strong>Fix:</strong><br>
Generate a 32-character random secret on first launch (same constructor block as Fix 1).
The secret is written into the sing-box <code>experimental.clash_api.secret</code> field by the
existing <code>buildExperimentalSection()</code> code, so no further changes are needed there.</p>
<hr>
<h3>Fix 3 — TLS certificate verification disabled without warning (High)</h3>
<p><strong>File:</strong> <code>src/ui/setting/dialog_basic_settings.cpp</code></p>
<p><strong>Problem:</strong><br>
When <code>net_insecure</code> is enabled, <code>HTTPRequestHelper</code> sets
<code>QSslSocket::PeerVerifyMode::VerifyNone</code> for <strong>all</strong> subscription requests.
A man-in-the-middle attacker on the network path between the client and the
subscription server can silently replace the subscription payload with a crafted
response that contains a malicious proxy profile, redirecting the user's traffic
through an attacker-controlled server.</p>
<p>The option could previously be toggled on with a single click and no confirmation.</p>
<p><strong>Fix:</strong><br>
Show a <code>QMessageBox::warning</code> dialog <strong>every time</strong> the checkbox transitions from
unchecked to checked, explicitly describing the MITM risk. If the user dismisses
the dialog without confirming, the checkbox is reverted to unchecked and the setting
is not saved.</p>
<pre><code class="language-cpp">if (newInsecure &amp;&amp; !wasInsecure) {
    auto btn = QMessageBox::warning(this, tr("Security Warning"),
        tr("Disabling TLS certificate verification exposes you to "
           "man-in-the-middle attacks.\n\n..."),
        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
    if (btn != QMessageBox::Yes) {
        ui-&gt;net_insecure-&gt;setChecked(false);
        newInsecure = false;
    }
}
</code></pre>
<hr>
<h3>Fix 4 — Hardware ID silently sent to subscription servers (High)</h3>
<p><strong>File:</strong> <code>src/ui/setting/dialog_basic_settings.cpp</code></p>
<p><strong>Problem:</strong><br>
When <code>sub_send_hwid</code> is enabled, every subscription HTTP request includes the
headers <code>x-hwid</code>, <code>x-device-os</code>, <code>x-ver-os</code>, and <code>x-device-model</code>. On Linux this
reads <code>/etc/machine-id</code>; on Windows it uses WMI (<code>Win32_BaseBoard</code>, <code>Win32_ComputerSystem</code>);
on macOS it uses <code>QSysInfo::machineUniqueId()</code>.</p>
<p>These identifiers are <strong>hardware-level, stable, and non-rotatable</strong>. A subscription
server can permanently fingerprint and track the specific physical device across IP
address changes and VPN sessions. This is a severe privacy risk for users in countries
with active internet censorship.</p>
<p>The option was already <code>false</code> by default (good), but could be enabled silently
with no warning about what data is transmitted.</p>
<p><strong>Fix:</strong><br>
Show a <code>QMessageBox::warning</code> dialog on the <code>false → true</code> transition with a
concrete list of the identifiers that will be sent. Dismissing the dialog reverts
the checkbox.</p>
<hr>
<h3>Fix 5 — DNS server exposed to LAN without warning (Medium)</h3>
<p><strong>File:</strong> <code>src/ui/setting/dialog_manage_routes.cpp</code></p>
<p><strong>Problem:</strong><br>
When <code>dns_server_listen_lan</code> is enabled, <code>buildInboundSection()</code> generates:</p>
<pre><code class="language-json">{ "listen": "0.0.0.0", "listen_port": 53 }
</code></pre>
<p>The DNS hijack server becomes reachable by every device on the local network,
potentially leaking the user's domain blocklists, routing rules, and overall
network topology to untrusted LAN peers.</p>
<p><strong>Fix:</strong><br>
Show a <code>QMessageBox::warning</code> dialog on the <code>false → true</code> transition, including
the specific <code>0.0.0.0:&lt;port&gt;</code> address that will be bound, and revert the checkbox
if the user does not confirm.</p>
<hr>
<h3>Fix 6 — Log injection via unsanitized subprocess output (Medium)</h3>
<p><strong>File:</strong> <code>src/sys/Process.cpp</code></p>
<p><strong>Problem:</strong><br>
The raw stdout and stderr of the sing-box child process were passed directly to
<code>MW_show_log()</code> without any sanitization. A malicious or compromised proxy
configuration could produce output containing:</p>
<ul>
<li><strong>ANSI / VT100 escape sequences</strong> — cursor movement, screen clear, colour codes
that can overwrite earlier log entries, hide error messages, or exploit log-viewer
rendering bugs</li>
<li><strong>C0 control characters</strong> — null bytes, bell, backspace, etc. that can confuse
downstream log parsers or UI components</li>
</ul>
<p><strong>Fix:</strong><br>
Added a <code>sanitizeLog()</code> helper function that:</p>
<ol>
<li>Removes ANSI escape sequences matching <code>\x1B\[[0-9;]*[A-Za-z]</code></li>
<li>Removes remaining lone <code>ESC</code> (<code>\x1B</code>) characters</li>
<li>Strips C0 control characters <code>\x00–\x1F</code> and <code>\x7F</code>, preserving only
<code>\x09</code> (HT), <code>\x0A</code> (LF), and <code>\x0D</code> (CR) which are needed for normal log formatting</li>
</ol>
<p>All <code>MW_show_log(log)</code> calls in both the stdout and stderr handlers are replaced
with <code>MW_show_log(sanitizeLog(log))</code>.</p>
<pre><code class="language-cpp">static inline QString sanitizeLog(const QByteArray &amp;raw) {
    QString s = QString::fromUtf8(raw);
    static const QRegularExpression ansiRe(QStringLiteral("\x1B\\[[0-9;]*[A-Za-z]"));
    s.remove(ansiRe);
    static const QRegularExpression escRe(QStringLiteral("\x1B[^\\[]?"));
    s.remove(escRe);
    static const QRegularExpression ctrlRe(
        QStringLiteral("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]"));
    s.remove(ctrlRe);
    return s;
}
</code></pre>
<hr>
<h2>Files changed</h2>

File | Changes
-- | --
src/database/SettingsRepo.cpp | First-launch generation of inbound credentials (Fix 1) and Clash API secret (Fix 2) with immediate DB persistence
src/sys/Process.cpp | sanitizeLog() function + applied to all subprocess output handlers (Fix 6)
src/ui/setting/dialog_basic_settings.cpp | Confirmation dialogs for net_insecure (Fix 3) and sub_send_hwid (Fix 4)
src/ui/setting/dialog_manage_routes.cpp | Confirmation dialog for dns_server_listen_lan (Fix 5)


<h2>Testing</h2>
<ul>
<li><strong>Fix 1:</strong> Fresh install (or cleared DB) → check that <code>inbound_auth</code>, <code>inbound_user</code>,
<code>inbound_pass</code> are non-empty in Settings and that <code>curl --proxy socks5://127.0.0.1:2080 https://example.com</code> fails without credentials</li>
<li><strong>Fix 2:</strong> Fresh install → verify <code>core_box_clash_api_secret</code> is non-empty in core
settings dialog</li>
<li><strong>Fix 3:</strong> Open Settings → Subscription → toggle "Insecure" on → confirm warning appears and checkbox reverts on "No"</li>
<li><strong>Fix 4:</strong> Open Settings → Subscription → toggle "Send HWID" on → confirm warning appears and checkbox reverts on "No"</li>
<li><strong>Fix 5:</strong> Open Routes → DNS Hijack → toggle "Allow LAN" on → confirm warning appears and checkbox reverts on "No"</li>
<li><strong>Fix 6:</strong> Start a profile with a config that emits ANSI codes (e.g. <code>\x1b[31mRED\x1b[0m</code>)
in its log output → verify the log view shows <code>RED</code> without colour codes or artifacts</li>
</ul></body></html># Security: Fix 6 vulnerabilities in local proxy, Clash API, TLS, HWID, DNS and log handling

## Summary

This PR addresses six security vulnerabilities discovered during a full audit of the
Throne client codebase. Four of them are **critical or high severity** and affect
all platforms (Windows, macOS, Linux).

The most important fix closes the unauthenticated local SOCKS5/HTTP inbound proxy
vulnerability described in [[this public disclosure](https://habr.com/ru/articles/1020080/)](https://habr.com/ru/articles/1020080/),
which affects all known xray/sing-box based clients and allows any process on the
device — including spyware — to detect the user's VPN server exit IP and SNI,
bypassing per-app split tunneling.

---

## Fixes

### Fix 1 — Unauthenticated local SOCKS5/HTTP inbound proxy (Critical)
**File:** `src/database/SettingsRepo.cpp`

**Problem:**  
`inbound_auth` defaults to `false` with empty `inbound_user` and `inbound_pass`.
The mixed (SOCKS5 + HTTP) inbound listener on port `2080` starts with **no
authentication**. Any process on the same machine — including OS-level spyware or
a malicious application — can:

- Connect to `127.0.0.1:2080` and route a request through the VPN tunnel
- Learn the external IP address and SNI of the user's VPN server
- Bypass per-app split tunneling even inside Android private spaces (Knox / Shelter /
  Island), since loopback is not isolated by `VpnService`
- Cause the VPN server to be identified and blocked by a censor

**Fix:**  
On first launch (detected by `inbound_user` being empty), generate cryptographically
random credentials via `GetRandomString()` and enable authentication by default.
The generated values are persisted to the database immediately so they survive restarts.
Users can still view or change the credentials in **Settings → Inbound**.

```cpp
// src/database/SettingsRepo.cpp — SettingsRepo constructor
bool needSave = false;
if (inbound_user.isEmpty()) {
    inbound_user = GetRandomString(16);
    inbound_pass = GetRandomString(24);
    inbound_auth = true;
    needSave = true;
}
if (core_box_clash_api_secret.isEmpty()) {
    core_box_clash_api_secret = GetRandomString(32);
    needSave = true;
}
if (needSave) Save();
```

---

### Fix 2 — Empty Clash API secret (Critical)
**File:** `src/database/SettingsRepo.cpp`

**Problem:**  
`core_box_clash_api_secret` defaults to an empty string. When the user enables the
Clash API (`core_box_clash_api > 0`), the sing-box control plane is reachable on
`127.0.0.1:<port>` **without any authentication token**. Any local process can:

- Enumerate and stop active outbound connections
- Read the full running configuration, including server addresses, ports, and
  authentication credentials
- Modify routing rules at runtime

**Fix:**  
Generate a 32-character random secret on first launch (same constructor block as Fix 1).
The secret is written into the sing-box `experimental.clash_api.secret` field by the
existing `buildExperimentalSection()` code, so no further changes are needed there.

---

### Fix 3 — TLS certificate verification disabled without warning (High)
**File:** `src/ui/setting/dialog_basic_settings.cpp`

**Problem:**  
When `net_insecure` is enabled, `HTTPRequestHelper` sets
`QSslSocket::PeerVerifyMode::VerifyNone` for **all** subscription requests.
A man-in-the-middle attacker on the network path between the client and the
subscription server can silently replace the subscription payload with a crafted
response that contains a malicious proxy profile, redirecting the user's traffic
through an attacker-controlled server.

The option could previously be toggled on with a single click and no confirmation.

**Fix:**  
Show a `QMessageBox::warning` dialog **every time** the checkbox transitions from
unchecked to checked, explicitly describing the MITM risk. If the user dismisses
the dialog without confirming, the checkbox is reverted to unchecked and the setting
is not saved.

```cpp
if (newInsecure && !wasInsecure) {
    auto btn = QMessageBox::warning(this, tr("Security Warning"),
        tr("Disabling TLS certificate verification exposes you to "
           "man-in-the-middle attacks.\n\n..."),
        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
    if (btn != QMessageBox::Yes) {
        ui->net_insecure->setChecked(false);
        newInsecure = false;
    }
}
```

---

### Fix 4 — Hardware ID silently sent to subscription servers (High)
**File:** `src/ui/setting/dialog_basic_settings.cpp`

**Problem:**  
When `sub_send_hwid` is enabled, every subscription HTTP request includes the
headers `x-hwid`, `x-device-os`, `x-ver-os`, and `x-device-model`. On Linux this
reads `/etc/machine-id`; on Windows it uses WMI (`Win32_BaseBoard`, `Win32_ComputerSystem`);
on macOS it uses `QSysInfo::machineUniqueId()`.

These identifiers are **hardware-level, stable, and non-rotatable**. A subscription
server can permanently fingerprint and track the specific physical device across IP
address changes and VPN sessions. This is a severe privacy risk for users in countries
with active internet censorship.

The option was already `false` by default (good), but could be enabled silently
with no warning about what data is transmitted.

**Fix:**  
Show a `QMessageBox::warning` dialog on the `false → true` transition with a
concrete list of the identifiers that will be sent. Dismissing the dialog reverts
the checkbox.

---

### Fix 5 — DNS server exposed to LAN without warning (Medium)
**File:** `src/ui/setting/dialog_manage_routes.cpp`

**Problem:**  
When `dns_server_listen_lan` is enabled, `buildInboundSection()` generates:

```json
{ "listen": "0.0.0.0", "listen_port": 53 }
```

The DNS hijack server becomes reachable by every device on the local network,
potentially leaking the user's domain blocklists, routing rules, and overall
network topology to untrusted LAN peers.

**Fix:**  
Show a `QMessageBox::warning` dialog on the `false → true` transition, including
the specific `0.0.0.0:<port>` address that will be bound, and revert the checkbox
if the user does not confirm.

---

### Fix 6 — Log injection via unsanitized subprocess output (Medium)
**File:** `src/sys/Process.cpp`

**Problem:**  
The raw stdout and stderr of the sing-box child process were passed directly to
`MW_show_log()` without any sanitization. A malicious or compromised proxy
configuration could produce output containing:

- **ANSI / VT100 escape sequences** — cursor movement, screen clear, colour codes
  that can overwrite earlier log entries, hide error messages, or exploit log-viewer
  rendering bugs
- **C0 control characters** — null bytes, bell, backspace, etc. that can confuse
  downstream log parsers or UI components

**Fix:**  
Added a `sanitizeLog()` helper function that:

1. Removes ANSI escape sequences matching `\x1B\[[0-9;]*[A-Za-z]`
2. Removes remaining lone `ESC` (`\x1B`) characters
3. Strips C0 control characters `\x00–\x1F` and `\x7F`, preserving only
   `\x09` (HT), `\x0A` (LF), and `\x0D` (CR) which are needed for normal log formatting

All `MW_show_log(log)` calls in both the stdout and stderr handlers are replaced
with `MW_show_log(sanitizeLog(log))`.

```cpp
static inline QString sanitizeLog(const QByteArray &raw) {
    QString s = QString::fromUtf8(raw);
    static const QRegularExpression ansiRe(QStringLiteral("\x1B\\[[0-9;]*[A-Za-z]"));
    s.remove(ansiRe);
    static const QRegularExpression escRe(QStringLiteral("\x1B[^\\[]?"));
    s.remove(escRe);
    static const QRegularExpression ctrlRe(
        QStringLiteral("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]"));
    s.remove(ctrlRe);
    return s;
}
```

---

## Files changed

| File | Changes |
|---|---|
| `src/database/SettingsRepo.cpp` | First-launch generation of inbound credentials (Fix 1) and Clash API secret (Fix 2) with immediate DB persistence |
| `src/sys/Process.cpp` | `sanitizeLog()` function + applied to all subprocess output handlers (Fix 6) |
| `src/ui/setting/dialog_basic_settings.cpp` | Confirmation dialogs for `net_insecure` (Fix 3) and `sub_send_hwid` (Fix 4) |
| `src/ui/setting/dialog_manage_routes.cpp` | Confirmation dialog for `dns_server_listen_lan` (Fix 5) |

## Severity overview

| # | Vulnerability | Severity | Fix type |
|---|---|---|---|
| 1 | Unauthenticated local SOCKS5/HTTP inbound (Habr disclosure) | 🔴 Critical | Auto-generate credentials on first launch |
| 2 | Empty Clash API secret | 🔴 Critical | Auto-generate secret on first launch |
| 3 | `net_insecure` enables silent MITM | 🟠 High | Confirmation dialog on enable |
| 4 | HWID leakage to subscription servers | 🟠 High | Confirmation dialog on enable |
| 5 | DNS server bound to `0.0.0.0` without warning | 🟡 Medium | Confirmation dialog on enable |
| 6 | Log injection via raw subprocess output | 🟡 Medium | `sanitizeLog()` strips ANSI + control chars |

## Testing

- **Fix 1:** Fresh install (or cleared DB) → check that `inbound_auth`, `inbound_user`,
  `inbound_pass` are non-empty in Settings and that `curl --proxy socks5://127.0.0.1:2080 https://example.com` fails without credentials
- **Fix 2:** Fresh install → verify `core_box_clash_api_secret` is non-empty in core
  settings dialog
- **Fix 3:** Open Settings → Subscription → toggle "Insecure" on → confirm warning appears and checkbox reverts on "No"
- **Fix 4:** Open Settings → Subscription → toggle "Send HWID" on → confirm warning appears and checkbox reverts on "No"
- **Fix 5:** Open Routes → DNS Hijack → toggle "Allow LAN" on → confirm warning appears and checkbox reverts on "No"
- **Fix 6:** Start a profile with a config that emits ANSI codes (e.g. `\x1b[31mRED\x1b[0m`)
  in its log output → verify the log view shows `RED` without colour codes or artifacts