### PR TITLE
fix #1388

### DIFF
--- a/src/sys/windows/AutoRun.cpp
+++ b/src/sys/windows/AutoRun.cpp
@@ -79,7 +79,8 @@ void enable_autorun() {
     QFile xmlFile(xmlFilePath);
     if (xmlFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream out(&xmlFile);
-        out.setEncoding(QStringConverter::Utf8);
+        out.setEncoding(QStringConverter::Utf16);
+        out.setGenerateByteOrderMark(true);
         out << xmlContent;
         xmlFile.close();
     }


### PR DESCRIPTION
Change task scheduler xml file encoding from UTF-8 to UTF-16 with BOM.